### PR TITLE
Exclude binary dirs in metrics script

### DIFF
--- a/tools/metrics.sh
+++ b/tools/metrics.sh
@@ -2,8 +2,20 @@
 # Collect repository metrics.
 set -e
 
-# Count source lines (crude estimate)
-line_count=$(find . -type f \( -name '*.[chsyl]' -o -name '*.sh' \) -print0 | xargs -0 cat | wc -l)
+# Directories that hold binary artifacts; skip them when counting lines
+# docs/vol2/anim includes prebuilt object code used in the documentation and
+# similar binary blobs appear in several other subdirectories.
+EXCLUDE_DIRS="docs/vol2/anim docs/vol2/Ped docs/vol2/sam docs/vol2/pi docs/man/man1"
+
+# Build prune expression for find
+prune=""
+for d in $EXCLUDE_DIRS; do
+    prune="$prune -path ./$(printf %s "$d") -o"
+done
+prune=${prune% -o}
+
+# Count source lines (crude estimate) while excluding the binary directories
+line_count=$(eval "find . \( $prune \) -prune -o -type f \( -name '*.[chsyl]' -o -name '*.sh' \) -print0" | xargs -0 cat | wc -l)
 echo "Total source lines: $line_count"
 
 type file >/dev/null 2>&1 && {


### PR DESCRIPTION
## Summary
- avoid counting docs/vol2/anim and other binary directories when measuring line count
- document the excluded directories

## Testing
- `sh tools/metrics.sh > /tmp/metrics_output.log`