### PR TITLE
Add spinlock support and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@
 test:
 	@echo "Running C23 tests..."
 	@cd modern/tests && ./c23_test.sh
+	@echo "Running spinlock tests..."
+	@cd modern/tests && ./spinlock_test.sh
 
 clean:
 	@rm -f modern/tests/c23_hello modern/tests/output.txt
+	@rm -f modern/tests/spinlock_test modern/tests/spinlock_output.txt

--- a/modern/tests/spinlock_test.c
+++ b/modern/tests/spinlock_test.c
@@ -1,0 +1,27 @@
+#include <pthread.h>
+#include <stdio.h>
+#include "../../v10/ipc/h/spinlock.h"
+
+static spinlock_t lock = SPINLOCK_INITIALIZER;
+static int counter = 0;
+
+void *worker(void *arg)
+{
+    for(int i=0; i<100000; i++) {
+        spin_lock(&lock);
+        counter++;
+        spin_unlock(&lock);
+    }
+    return NULL;
+}
+
+int main(void)
+{
+    pthread_t t1, t2;
+    pthread_create(&t1, NULL, worker, NULL);
+    pthread_create(&t2, NULL, worker, NULL);
+    pthread_join(t1, NULL);
+    pthread_join(t2, NULL);
+    printf("counter=%d\n", counter);
+    return counter==200000 ? 0 : 1;
+}

--- a/modern/tests/spinlock_test.sh
+++ b/modern/tests/spinlock_test.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+cc -pthread spinlock_test.c ../../v10/ipc/spinlock.c -I ../../v10/ipc/h -DSMP_ENABLED -o spinlock_test
+./spinlock_test > spinlock_output.txt
+if grep -q "counter=200000" spinlock_output.txt; then
+    echo "spinlock test passed"
+    exit 0
+else
+    echo "spinlock test failed" >&2
+    exit 1
+fi

--- a/v10/ipc/h/spinlock.h
+++ b/v10/ipc/h/spinlock.h
@@ -1,0 +1,48 @@
+#ifndef SPINLOCK_H
+#define SPINLOCK_H
+
+#include <stdint.h>
+
+#if defined(__x86_64__) || defined(__i386__)
+static inline unsigned spinlock_cache_line_size(void)
+{
+    unsigned int eax, ebx, ecx, edx;
+    eax = 0x80000006;
+    __asm__ __volatile__("cpuid" : "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx) : "a"(eax));
+    if(ecx & 0xFF)
+        return ecx & 0xFF;
+    return 64;
+}
+#else
+static inline unsigned spinlock_cache_line_size(void)
+{
+    return 64;
+}
+#endif
+
+#ifndef CACHE_LINE_SIZE
+#define CACHE_LINE_SIZE 64
+#endif
+
+#ifdef USE_TICKET_LOCK
+typedef struct {
+    volatile unsigned next;
+    volatile unsigned owner;
+} spinlock_t __attribute__((aligned(CACHE_LINE_SIZE)));
+#else
+typedef struct {
+    volatile int locked;
+} spinlock_t __attribute__((aligned(CACHE_LINE_SIZE)));
+#endif
+
+#define SPINLOCK_INITIALIZER {0}
+
+#ifdef SMP_ENABLED
+void spin_lock(spinlock_t *lock);
+void spin_unlock(spinlock_t *lock);
+#else
+#define spin_lock(l) ((void)0)
+#define spin_unlock(l) ((void)0)
+#endif
+
+#endif /* SPINLOCK_H */

--- a/v10/ipc/libipc/ipcexec.c
+++ b/v10/ipc/libipc/ipcexec.c
@@ -1,5 +1,7 @@
 #include <ipc.h>
 #include "defs.h"
+#include "spinlock.h"
+extern spinlock_t ipc_lock;
 
 /*
  *  Perform a remote execution of a command.
@@ -37,11 +39,13 @@ _ipcexec(name, def, service, param, cmd)
 		return -1;
 	}
 	len = strlen(cmd)+1;
-	if (write(fd, cmd, len)!=len) {
-		errstr = "write error";
-		close(fd);
-		return -1;
-	}
+       if (write(fd, cmd, len)!=len) {
+               spin_lock(&ipc_lock);
+               errstr = "write error";
+               spin_unlock(&ipc_lock);
+               close(fd);
+               return -1;
+       }
 	return fd;
 }
 

--- a/v10/ipc/libipc/ipcmesgexec.c
+++ b/v10/ipc/libipc/ipcmesgexec.c
@@ -1,5 +1,7 @@
 #include <ipc.h>
 #include "defs.h"
+#include "spinlock.h"
+extern spinlock_t ipc_lock;
 
 extern int mesg_ld;
 
@@ -25,10 +27,12 @@ ipcmesgexec(name, param, cmd)
 		return -1;
 	}
 	len = strlen(cmd)+1;
-	if (write(fd, cmd, len)!=len) {
-		errstr = "write error";
-		close(fd);
-		return -1;
-	}
+       if (write(fd, cmd, len)!=len) {
+               spin_lock(&ipc_lock);
+               errstr = "write error";
+               spin_unlock(&ipc_lock);
+               close(fd);
+               return -1;
+       }
 	return fd;
 }

--- a/v10/ipc/libipc/ipcopen.c
+++ b/v10/ipc/libipc/ipcopen.c
@@ -3,9 +3,11 @@
 #include <sys/stat.h>
 #include <ipc.h>
 #include "defs.h"
+#include "spinlock.h"
 
 /* exported */
 char *errstr;
+extern spinlock_t ipc_lock;
 
 /* imports */
 extern int atoi();
@@ -230,8 +232,10 @@ _ipcabort(no, err, ip)
 			ip->rfd = -1;
 		}
 	}
-	errstr = err;
-	errno = no;
-	return -1;
+       spin_lock(&ipc_lock);
+       errstr = err;
+       spin_unlock(&ipc_lock);
+       errno = no;
+       return -1;
 }
 

--- a/v10/ipc/libipc/mkfile
+++ b/v10/ipc/libipc/mkfile
@@ -2,9 +2,9 @@ INCS=-I. -I../h
 CFLAGS=-g $INCS
 L=libipc.a
 OBJS=$L(ipcopen.o) $L(ipccreat.o) $L(ipcproto.o) $L(pwsearch.o) $L(ipclogin.o)\
-    $L(ipcpath.o) $L(ipcexec.o) $L(ipcbuf.o) $L(qns.o)
+    $L(ipcpath.o) $L(ipcexec.o) $L(ipcbuf.o) $L(qns.o) $L(spinlock.o)
 COBJS=ipcopen.O ipccreat.O ipcproto.O pwsearch.O ipclogin.O ipcpath.O\
-    ipcexec.O ipcbuf.O qns.O
+    ipcexec.O ipcbuf.O qns.O spinlock.O
 NPROC=2
 
 all:V: cyntax $L

--- a/v10/ipc/spinlock.c
+++ b/v10/ipc/spinlock.c
@@ -1,0 +1,33 @@
+#include "h/spinlock.h"
+
+spinlock_t ipc_lock = SPINLOCK_INITIALIZER;
+
+#ifdef SMP_ENABLED
+#ifndef USE_TICKET_LOCK
+void spin_lock(spinlock_t *lock)
+{
+    while(__sync_lock_test_and_set(&lock->locked, 1)) {
+        while(lock->locked)
+            ;
+    }
+}
+
+void spin_unlock(spinlock_t *lock)
+{
+    __sync_lock_release(&lock->locked);
+}
+#else
+void spin_lock(spinlock_t *lock)
+{
+    unsigned ticket = __sync_fetch_and_add(&lock->next, 1);
+    while(__sync_val_compare_and_swap(&lock->owner, ticket, ticket) != ticket) {
+        /* busy wait */
+    }
+}
+
+void spin_unlock(spinlock_t *lock)
+{
+    __sync_fetch_and_add(&lock->owner, 1);
+}
+#endif
+#endif /* SMP_ENABLED */


### PR DESCRIPTION
## Summary
- implement generic spinlock in `v10/ipc`
- guard shared IPC variables with new lock primitives
- build new spinlock test alongside existing C23 demo
- update metrics

## Testing
- `make test`
- `tools/metrics.sh`