### PR TITLE
Make C23 test compiler configurable

### DIFF
--- a/README
+++ b/README
@@ -62,5 +62,7 @@ Run the C23 test suite with:
 
     make test
 
+The script honors the CC environment variable, defaulting to `cc`.
+
 The command compiles a small C23 example under `modern/tests/` and
 checks that it runs correctly.

--- a/modern/tests/c23_test.sh
+++ b/modern/tests/c23_test.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 # Build and run the C23 demo program.
+CC=${CC:-cc}
 set -e
-cc -std=c2x c23_hello.c -o c23_hello
+$CC -std=c2x c23_hello.c -o c23_hello
 ./c23_hello > output.txt
 if grep -q "Hello from C23" output.txt; then
     echo "C23 executable ran successfully"


### PR DESCRIPTION
## Summary
- allow overriding `cc` compiler in `c23_test.sh`
- document `CC` variable in README

## Testing
- `make test`