### PR TITLE
Add analysis docs for page fault and IP reassembly

### DIFF
--- a/docs/analysis/ip_reassembly.md
+++ b/docs/analysis/ip_reassembly.md
@@ -1,0 +1,25 @@
+# IP Fragment Reassembly
+
+This note outlines the main phases of `ip_reass()` and how the timeout
+handler cleans up unfinished fragment queues.
+
+## ip_reass() flow
+1. **Locate or create reassembly queue:** The function searches the
+global `ipq` list for an entry matching the fragment's ID, source,
+destination, and protocol. If the packet is not a fragment, any existing
+queue for that ID is discarded and the packet is returned unchanged
+(lines 135–153 of `ip_input.c`). If no queue exists, a new one is
+allocated and inserted at the head of `ipq` (lines 155–178).
+2. **Insert the fragment:** The code finds the proper position in the
+fragment list, trimming overlaps with previous or subsequent fragments
+(lines 185–224). The new fragment is then linked into the chain and the
+routine checks if the sequence of offsets is contiguous (lines 226–246).
+3. **Assemble final packet:** When all fragments have arrived, the
+routine concatenates the data blocks, updates the header, removes the
+queue header, and returns a complete datagram (lines 248–270).
+
+## Timeout handling
+The `ip_slowtimo()` routine decrements a TTL counter in each reassembly
+queue. When the counter reaches zero, the entire queue is freed
+(lines 308–319 of `ip_input.c`). This function is periodically rescheduled
+using `timeout()` so stale fragment queues are cleaned up automatically.

--- a/docs/analysis/page_fault.md
+++ b/docs/analysis/page_fault.md
@@ -1,0 +1,43 @@
+# pagein() Overview
+
+This document summarizes the high-level logic used by the `pagein()`
+routine in the Research UNIX V10 kernel.
+
+## Reclaim logic
+When a fault occurs, `pagein()` first checks whether the page is already
+allocated but merely invalid.  If so, and the physical page can be
+reclaimed, the routine pulls it back into the process's resident set
+instead of issuing disk I/O.  The key steps start around the `restart:`
+label and include waiting for in-transit text pages and revalidating the
+entry if it becomes valid during the wait:
+
+```c
+...  /* reclaim or revalidate */
+```
+(see lines 94–154 of `vmpage.c`)
+
+## Swap read path
+If the page is not already present, the routine must read it from the
+swap device.  After determining the swap block (`bn`) and possibly
+clustering adjacent pages via `kluster()`, the code calls `swap()` to
+perform the actual disk read:
+
+```c
+swap(p, fsbtodb(dev, bn), ptob(v), klsize * ctob(CLSIZE), B_READ, B_PGIN, dev, 0);
+```
+(see lines 324–343 of `vmpage.c`)
+
+## Zero-fill on demand
+For demand-zero pages, `pagein()` avoids disk I/O by simply clearing the
+freshly allocated page frames.  The zero-fill logic clears each page in
+the cluster and counts it as a zero-fill fault before skipping the swap
+operation entirely:
+
+```c
+for (i = 0; i < CLSIZE; i++)
+    clearseg(pf + i);
+if (type != CTEXT)
+    cnt.v_zfod += CLSIZE;
+```
+(see lines 295–299 of `vmpage.c`)
+


### PR DESCRIPTION
## Summary
- add `docs/analysis` for walkthrough material
- document `pagein()` fault handling
- document `ip_reass()` algorithm and timeout cleanup

## Testing
- `make test`