### PR TITLE
Modernize x86 support

### DIFF
--- a/modern/compat/svr4/svr4_machdep.h
+++ b/modern/compat/svr4/svr4_machdep.h
@@ -29,8 +29,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef _I386_SVR4_MACHDEP_H_
-#define _I386_SVR4_MACHDEP_H_
+#ifndef _X86_SVR4_MACHDEP_H_
+#define _X86_SVR4_MACHDEP_H_
 
 #include <compat/svr4/svr4_types.h>
 
@@ -38,6 +38,35 @@
  * Machine dependent portions [X86]
  */
 
+#if defined(__x86_64__)
+#define SVR4_X86_RDI     0
+#define SVR4_X86_RSI     1
+#define SVR4_X86_RBP     2
+#define SVR4_X86_RBX     3
+#define SVR4_X86_RDX     4
+#define SVR4_X86_RCX     5
+#define SVR4_X86_RAX     6
+#define SVR4_X86_TRAPNO  7
+#define SVR4_X86_ERR     8
+#define SVR4_X86_RIP     9
+#define SVR4_X86_CS      10
+#define SVR4_X86_RFL     11
+#define SVR4_X86_RSP     12
+#define SVR4_X86_SS      13
+#define SVR4_X86_GS      14
+#define SVR4_X86_FS      15
+#define SVR4_X86_ES      16
+#define SVR4_X86_DS      17
+#define SVR4_X86_R8      18
+#define SVR4_X86_R9      19
+#define SVR4_X86_R10     20
+#define SVR4_X86_R11     21
+#define SVR4_X86_R12     22
+#define SVR4_X86_R13     23
+#define SVR4_X86_R14     24
+#define SVR4_X86_R15     25
+#define SVR4_X86_MAXREG  26
+#else
 #define SVR4_X86_GS      0
 #define SVR4_X86_FS      1
 #define SVR4_X86_ES      2
@@ -58,9 +87,17 @@
 #define SVR4_X86_UESP    17
 #define SVR4_X86_SS      18
 #define SVR4_X86_MAXREG  19
+#endif
 
 
+/*
+ * Define register types based on architecture.
+ */
+#if defined(__x86_64__)
+typedef long svr4_greg_t;
+#else
 typedef int svr4_greg_t;
+#endif
 typedef svr4_greg_t svr4_gregset_t[SVR4_X86_MAXREG];
 
 typedef struct {
@@ -123,4 +160,4 @@ struct svr4_ssd {
 
 void svr4_syscall_intern(struct proc *);
 
-#endif /* !_I386_SVR4_MACHDEP_H_ */
+#endif /* !_X86_SVR4_MACHDEP_H_ */

--- a/v10/ipc/h/spinlock.h
+++ b/v10/ipc/h/spinlock.h
@@ -6,10 +6,33 @@
 #if defined(__x86_64__) || defined(__i386__)
 static inline unsigned spinlock_cache_line_size(void)
 {
+#if defined(__i386__)
+    unsigned int flags, tmp;
+
+    __asm__ volatile(
+        "pushfl\n\t"
+        "popl %0\n\t"
+        "movl %0,%1\n\t"
+        "xorl $0x200000,%0\n\t"
+        "pushl %0\n\t"
+        "popfl\n\t"
+        "pushfl\n\t"
+        "popl %0\n\t"
+        "xorl %1,%0"
+        : "=&r"(flags), "=&r"(tmp)
+        :
+        : "cc");
+
+    if (!(flags & 0x200000))
+        return 64;
+#endif
+
     unsigned int eax, ebx, ecx, edx;
     eax = 0x80000006;
-    __asm__ __volatile__("cpuid" : "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx) : "a"(eax));
-    if(ecx & 0xFF)
+    __asm__ __volatile__("cpuid"
+                         : "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx)
+                         : "a"(eax));
+    if (ecx & 0xFF)
         return ecx & 0xFF;
     return 64;
 }


### PR DESCRIPTION
## Summary
- handle CPUID absence on 386 in spinlock.h
- add x86_64 register definitions in `svr4_machdep.h`
- use 64-bit greg_t on x86_64

## Testing
- `make test`