### PR TITLE
Add stress tests and Makefile check target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,9 @@
-.PHONY: test clean
+.PHONY: test clean check
 
-test:
-	@echo "Running C23 tests..."
-	@cd modern/tests && ./c23_test.sh
-	@echo "Running spinlock tests..."
-	@cd modern/tests && ./spinlock_test.sh
+test: check
+
+check:
+	$(MAKE) -C modern/tests check
 
 clean:
-	@rm -f modern/tests/c23_hello modern/tests/output.txt
-	@rm -f modern/tests/spinlock_test modern/tests/spinlock_output.txt
+	$(MAKE) -C modern/tests clean

--- a/modern/tests/Makefile
+++ b/modern/tests/Makefile
@@ -1,0 +1,33 @@
+CC ?= cc
+CFLAGS = -pthread -I ../../v10/ipc/h -DSMP_ENABLED
+SPINLOCK_SRC = ../../v10/ipc/spinlock.c
+
+TESTS = c23_hello spinlock_test thread_spinlock_stress \
+	process_spinlock_stress ptrace_concurrency_test
+
+all: $(TESTS)
+
+c23_hello: c23_hello.c
+	$(CC) -std=c2x $< -o $@
+
+spinlock_test: spinlock_test.c $(SPINLOCK_SRC)
+	$(CC) $(CFLAGS) $< $(SPINLOCK_SRC) -o $@
+
+thread_spinlock_stress: thread_spinlock_stress.c $(SPINLOCK_SRC)
+	$(CC) $(CFLAGS) $< $(SPINLOCK_SRC) -o $@
+
+process_spinlock_stress: process_spinlock_stress.c $(SPINLOCK_SRC)
+	$(CC) $(CFLAGS) $< $(SPINLOCK_SRC) -o $@
+
+ptrace_concurrency_test: ptrace_concurrency_test.c
+	$(CC) $(CFLAGS) $< -o $@
+
+check: all
+	./c23_test.sh
+	./spinlock_test.sh
+	./thread_spinlock_stress.sh
+	./process_spinlock_stress.sh
+	./ptrace_concurrency_test.sh
+
+clean:
+	rm -f $(TESTS) *.txt

--- a/modern/tests/process_spinlock_stress.c
+++ b/modern/tests/process_spinlock_stress.c
@@ -1,0 +1,45 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include "../../v10/ipc/h/spinlock.h"
+
+#define PROCESSES 4
+#define ITERATIONS 10000
+
+typedef struct {
+    spinlock_t lock;
+    int counter;
+} shared_t;
+
+int main(void)
+{
+    shared_t *shared = mmap(NULL, sizeof(shared_t), PROT_READ|PROT_WRITE,
+                            MAP_SHARED|MAP_ANONYMOUS, -1, 0);
+    if(shared == MAP_FAILED) {
+        perror("mmap");
+        return 1;
+    }
+    shared->lock = (spinlock_t)SPINLOCK_INITIALIZER;
+    shared->counter = 0;
+
+    for(int i = 0; i < PROCESSES; i++) {
+        pid_t pid = fork();
+        if(pid == 0) {
+            for(int j = 0; j < ITERATIONS; j++) {
+                spin_lock(&shared->lock);
+                shared->counter++;
+                spin_unlock(&shared->lock);
+            }
+            _exit(0);
+        }
+    }
+
+    for(int i = 0; i < PROCESSES; i++)
+        wait(NULL);
+
+    printf("counter=%d\n", shared->counter);
+    int expected = PROCESSES * ITERATIONS;
+    return shared->counter == expected ? 0 : 1;
+}

--- a/modern/tests/process_spinlock_stress.sh
+++ b/modern/tests/process_spinlock_stress.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+cc -pthread process_spinlock_stress.c ../../v10/ipc/spinlock.c -I ../../v10/ipc/h -DSMP_ENABLED -o process_spinlock_stress
+./process_spinlock_stress > process_spinlock_output.txt
+if grep -q "counter=40000" process_spinlock_output.txt; then
+    echo "process spinlock stress test passed"
+    exit 0
+else
+    echo "process spinlock stress test failed" >&2
+    exit 1
+fi

--- a/modern/tests/ptrace_concurrency_test.c
+++ b/modern/tests/ptrace_concurrency_test.c
@@ -1,0 +1,53 @@
+#include <pthread.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/ptrace.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define CHILDREN 4
+
+static pid_t children[CHILDREN];
+
+void *tracer(void *arg)
+{
+    pid_t pid = *(pid_t *)arg;
+    if(ptrace(PTRACE_ATTACH, pid, NULL, NULL) == -1) {
+        perror("ptrace attach");
+        return (void *)1;
+    }
+    waitpid(pid, NULL, 0);
+    ptrace(PTRACE_CONT, pid, NULL, NULL);
+    usleep(100000);
+    ptrace(PTRACE_DETACH, pid, NULL, NULL);
+    return NULL;
+}
+
+int main(void)
+{
+    for(int i = 0; i < CHILDREN; i++) {
+        pid_t pid = fork();
+        if(pid == 0) {
+            raise(SIGSTOP);
+            pause();
+            _exit(0);
+        }
+        children[i] = pid;
+    }
+
+    pthread_t th[CHILDREN];
+    for(int i = 0; i < CHILDREN; i++)
+        pthread_create(&th[i], NULL, tracer, &children[i]);
+    for(int i = 0; i < CHILDREN; i++)
+        pthread_join(th[i], NULL);
+
+    for(int i = 0; i < CHILDREN; i++) {
+        kill(children[i], SIGKILL);
+        waitpid(children[i], NULL, 0);
+    }
+
+    printf("ptrace concurrency test completed\n");
+    return 0;
+}

--- a/modern/tests/ptrace_concurrency_test.sh
+++ b/modern/tests/ptrace_concurrency_test.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+cc -pthread ptrace_concurrency_test.c -o ptrace_concurrency_test
+./ptrace_concurrency_test > ptrace_concurrency_output.txt
+if grep -q "ptrace concurrency test completed" ptrace_concurrency_output.txt; then
+    echo "ptrace concurrency test passed"
+    exit 0
+else
+    echo "ptrace concurrency test failed" >&2
+    exit 1
+fi

--- a/modern/tests/thread_spinlock_stress.c
+++ b/modern/tests/thread_spinlock_stress.c
@@ -1,0 +1,30 @@
+#include <pthread.h>
+#include <stdio.h>
+#include "../../v10/ipc/h/spinlock.h"
+
+#define THREADS 4
+#define ITERATIONS 100000
+
+static spinlock_t lock = SPINLOCK_INITIALIZER;
+static int counter = 0;
+
+void *worker(void *arg)
+{
+    for(int i = 0; i < ITERATIONS; i++) {
+        spin_lock(&lock);
+        counter++;
+        spin_unlock(&lock);
+    }
+    return NULL;
+}
+
+int main(void)
+{
+    pthread_t t[THREADS];
+    for(int i = 0; i < THREADS; i++)
+        pthread_create(&t[i], NULL, worker, NULL);
+    for(int i = 0; i < THREADS; i++)
+        pthread_join(t[i], NULL);
+    printf("counter=%d\n", counter);
+    return counter == THREADS * ITERATIONS ? 0 : 1;
+}

--- a/modern/tests/thread_spinlock_stress.sh
+++ b/modern/tests/thread_spinlock_stress.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+cc -pthread thread_spinlock_stress.c ../../v10/ipc/spinlock.c -I ../../v10/ipc/h -DSMP_ENABLED -o thread_spinlock_stress
+./thread_spinlock_stress > thread_spinlock_output.txt
+if grep -q "counter=400000" thread_spinlock_output.txt; then
+    echo "thread spinlock stress test passed"
+    exit 0
+else
+    echo "thread spinlock stress test failed" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- add check target to root Makefile that runs tests in modern/tests
- provide Makefile under modern/tests to compile and run all tests
- add thread-based spinlock stress test
- add process-based spinlock stress test
- add concurrent ptrace test

## Testing
- `make check`
- `make clean`