### PR TITLE
Use C23 atomics for spinlocks

### DIFF
--- a/modern/tests/Makefile
+++ b/modern/tests/Makefile
@@ -1,15 +1,15 @@
 CROSS_COMPILE ?=
 CC ?= $(CROSS_COMPILE)gcc
-CFLAGS = -pthread -I ../../v10/ipc/h -DSMP_ENABLED
+CFLAGS = -std=c23 -pthread -I ../../v10/ipc/h -DSMP_ENABLED
 SPINLOCK_SRC = ../../v10/ipc/spinlock.c
 
 TESTS = c23_hello spinlock_test thread_spinlock_stress \
-        process_spinlock_stress ptrace_concurrency_test spinlock_fairness
+	process_spinlock_stress ptrace_concurrency_test spinlock_fairness
 
 all: $(TESTS)
 
 c23_hello: c23_hello.c
-	$(CC) -std=c2x $< -o $@
+	$(CC) $(CFLAGS) $< -o $@
 
 spinlock_test: spinlock_test.c $(SPINLOCK_SRC)
 	$(CC) $(CFLAGS) $< $(SPINLOCK_SRC) -o $@

--- a/modern/tests/process_spinlock_stress.sh
+++ b/modern/tests/process_spinlock_stress.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-cc -pthread process_spinlock_stress.c ../../v10/ipc/spinlock.c -I ../../v10/ipc/h -DSMP_ENABLED -o process_spinlock_stress
+cc -std=c23 -pthread process_spinlock_stress.c ../../v10/ipc/spinlock.c -I ../../v10/ipc/h -DSMP_ENABLED -o process_spinlock_stress
 ./process_spinlock_stress > process_spinlock_output.txt
 if grep -q "counter=40000" process_spinlock_output.txt; then
     echo "process spinlock stress test passed"

--- a/modern/tests/ptrace_concurrency_test.sh
+++ b/modern/tests/ptrace_concurrency_test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-cc -pthread ptrace_concurrency_test.c -o ptrace_concurrency_test
+cc -std=c23 -pthread ptrace_concurrency_test.c -o ptrace_concurrency_test
 ./ptrace_concurrency_test > ptrace_concurrency_output.txt
 if grep -q "ptrace concurrency test completed" ptrace_concurrency_output.txt; then
     echo "ptrace concurrency test passed"

--- a/modern/tests/spinlock_test.sh
+++ b/modern/tests/spinlock_test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-cc -pthread spinlock_test.c ../../v10/ipc/spinlock.c -I ../../v10/ipc/h -DSMP_ENABLED -o spinlock_test
+cc -std=c23 -pthread spinlock_test.c ../../v10/ipc/spinlock.c -I ../../v10/ipc/h -DSMP_ENABLED -o spinlock_test
 ./spinlock_test > spinlock_output.txt
 if grep -q "counter=200000" spinlock_output.txt; then
     echo "spinlock test passed"

--- a/modern/tests/thread_spinlock_stress.sh
+++ b/modern/tests/thread_spinlock_stress.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-cc -pthread thread_spinlock_stress.c ../../v10/ipc/spinlock.c -I ../../v10/ipc/h -DSMP_ENABLED -o thread_spinlock_stress
+cc -std=c23 -pthread thread_spinlock_stress.c ../../v10/ipc/spinlock.c -I ../../v10/ipc/h -DSMP_ENABLED -o thread_spinlock_stress
 ./thread_spinlock_stress > thread_spinlock_output.txt
 if grep -q "counter=400000" thread_spinlock_output.txt; then
     echo "thread spinlock stress test passed"

--- a/v10/ipc/h/spinlock.h
+++ b/v10/ipc/h/spinlock.h
@@ -2,6 +2,7 @@
 #define SPINLOCK_H
 
 #include <stdint.h>
+#include <stdatomic.h>
 
 #if defined(__x86_64__) || defined(__i386__)
 static inline unsigned spinlock_cache_line_size(void)
@@ -49,16 +50,16 @@ static inline unsigned spinlock_cache_line_size(void)
 
 #ifdef USE_TICKET_LOCK
 typedef struct {
-    volatile unsigned next;
-    volatile unsigned owner;
+    atomic_uint next;
+    atomic_uint owner;
 } spinlock_t __attribute__((aligned(CACHE_LINE_SIZE)));
+#define SPINLOCK_INITIALIZER { ATOMIC_VAR_INIT(0), ATOMIC_VAR_INIT(0) }
 #else
 typedef struct {
-    volatile int locked;
+    atomic_flag locked;
 } spinlock_t __attribute__((aligned(CACHE_LINE_SIZE)));
+#define SPINLOCK_INITIALIZER { ATOMIC_FLAG_INIT }
 #endif
-
-#define SPINLOCK_INITIALIZER {0}
 
 #ifdef SMP_ENABLED
 void spin_lock(spinlock_t *lock);

--- a/v10/ipc/spinlock.c
+++ b/v10/ipc/spinlock.c
@@ -6,28 +6,27 @@ spinlock_t ipc_lock = SPINLOCK_INITIALIZER;
 #ifndef USE_TICKET_LOCK
 void spin_lock(spinlock_t *lock)
 {
-    while(__sync_lock_test_and_set(&lock->locked, 1)) {
-        while(lock->locked)
-            ;
-    }
-}
-
-void spin_unlock(spinlock_t *lock)
-{
-    __sync_lock_release(&lock->locked);
-}
-#else
-void spin_lock(spinlock_t *lock)
-{
-    unsigned ticket = __sync_fetch_and_add(&lock->next, 1);
-    while(__sync_val_compare_and_swap(&lock->owner, ticket, ticket) != ticket) {
+    while (atomic_flag_test_and_set_explicit(&lock->locked, memory_order_acquire)) {
         /* busy wait */
     }
 }
 
 void spin_unlock(spinlock_t *lock)
 {
-    __sync_fetch_and_add(&lock->owner, 1);
+    atomic_flag_clear_explicit(&lock->locked, memory_order_release);
+}
+#else
+void spin_lock(spinlock_t *lock)
+{
+    unsigned ticket = atomic_fetch_add_explicit(&lock->next, 1u, memory_order_relaxed);
+    while (atomic_load_explicit(&lock->owner, memory_order_acquire) != ticket) {
+        /* busy wait */
+    }
+}
+
+void spin_unlock(spinlock_t *lock)
+{
+    atomic_fetch_add_explicit(&lock->owner, 1u, memory_order_release);
 }
 #endif
 #endif /* SMP_ENABLED */


### PR DESCRIPTION
## Summary
- implement spin locks using `atomic_flag` / `atomic_uint`
- update `spinlock_t` definition for atomics
- compile modern tests with `-std=c23`

## Testing
- `make check` *(fails: unrecognized option `-std=c23`)*