### PR TITLE
Add architecture selection for cross-compiling

### DIFF
--- a/README
+++ b/README
@@ -70,15 +70,15 @@ checks that it runs correctly.
 Cross compiling
 ---------------
 Before running `make` with a cross compiler, source the helper script
-and pass it your toolchain prefix:
+and pass it the desired architecture:
 
 ```sh
-. tools/cross-env.sh i386-linux-gnu-
+. tools/cross-env.sh x86_64
 ```
 
-Replace the argument with the desired target triple such as
-`vax-unknown-linux-gnu-`.  The script exports `CROSS_COMPILE`, `CC` and
-other variables used by the Makefiles.
+The script chooses an appropriate prefix such as
+`x86_64-linux-gnu-` and exports `CROSS_COMPILE`, `CC` and other
+variables used by the Makefiles.
 
 Booting in QEMU
 ---------------

--- a/modern/tests/Makefile
+++ b/modern/tests/Makefile
@@ -1,3 +1,4 @@
+# Set CROSS_COMPILE using `source tools/cross-env.sh <arch>`
 CROSS_COMPILE ?=
 CC ?= $(CROSS_COMPILE)gcc
 CFLAGS = -pthread -I ../../v10/ipc/h -DSMP_ENABLED

--- a/tools/cross-env.sh
+++ b/tools/cross-env.sh
@@ -1,13 +1,39 @@
-# Usage: source tools/cross-env.sh <target-triple-prefix>
-# Example: source tools/cross-env.sh i386-linux-gnu-
-# Sets CROSS_COMPILE, CC, AR, AS, LD, RANLIB and STRIP variables.
+# Usage: source tools/cross-env.sh <architecture>
+# Example: source tools/cross-env.sh x86_64
+#
+# Exports CROSS_COMPILE, CC, AR, AS, LD, RANLIB and STRIP variables
+# according to the selected architecture.  The script is meant to be
+# sourced before invoking make.
 
 if [ -z "$1" ]; then
-    echo "usage: . tools/cross-env.sh <target-triple-prefix>" >&2
+    echo "usage: . tools/cross-env.sh <architecture>" >&2
     return 1
 fi
 
-export CROSS_COMPILE="${1}"
+arch="$1"
+
+case "$arch" in
+    x86_64)
+        prefix="x86_64-linux-gnu-"
+        ;;
+    i[3-6]86|x86)
+        prefix="i686-linux-gnu-"
+        ;;
+    armv7|arm)
+        prefix="arm-linux-gnueabi-"
+        ;;
+    aarch64)
+        prefix="aarch64-linux-gnu-"
+        ;;
+    vax)
+        prefix="vax-unknown-linux-gnu-"
+        ;;
+    *)
+        prefix="${arch}-linux-gnu-"
+        ;;
+esac
+
+export CROSS_COMPILE="${prefix}"
 
 export CC="${CC:-${CROSS_COMPILE}gcc}"
 export AR="${AR:-${CROSS_COMPILE}ar}"

--- a/v10/asm.libm/Makefile
+++ b/v10/asm.libm/Makefile
@@ -1,3 +1,4 @@
+# Set CROSS_COMPILE using `source tools/cross-env.sh <arch>`
 CROSS_COMPILE ?=
 CC ?= $(CROSS_COMPILE)gcc
 AR ?= $(CROSS_COMPILE)ar

--- a/v10/libj/Makefile
+++ b/v10/libj/Makefile
@@ -1,3 +1,4 @@
+# Set CROSS_COMPILE using `source tools/cross-env.sh <arch>`
 CROSS_COMPILE ?=
 CC ?= $(CROSS_COMPILE)gcc
 AR ?= $(CROSS_COMPILE)ar


### PR DESCRIPTION
## Summary
- extend `tools/cross-env.sh` to accept an architecture name and pick the
  appropriate toolchain prefix
- document the new usage in `README`
- hint at using `cross-env.sh` in Makefiles that expect `CROSS_COMPILE`

## Testing
- `make check`