### PR TITLE
Add missing license headers

### DIFF
--- a/v10/cmd/egrep/anal.c
+++ b/v10/cmd/egrep/anal.c
@@ -1,3 +1,20 @@
+/* Origin: /usr/src/ucb/grep/anal.c */
+/*-
+ * Copyright (c) 1983 Regents of the University of California.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms are permitted
+ * provided that the above copyright notice and this paragraph are
+ * duplicated in all such forms and that any documentation,
+ * advertising materials, and other materials related to such
+ * distribution and use acknowledge that the software was developed
+ * by the University of California, Berkeley.  The name of the
+ * University may not be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+ * WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ */
 #include	"hdr.h"
 #include	"y.tab.h"
 

--- a/v10/cmd/egrep/bm.c
+++ b/v10/cmd/egrep/bm.c
@@ -1,3 +1,20 @@
+/* Origin: /usr/src/ucb/grep/bm.c */
+/*-
+ * Copyright (c) 1983 Regents of the University of California.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms are permitted
+ * provided that the above copyright notice and this paragraph are
+ * duplicated in all such forms and that any documentation,
+ * advertising materials, and other materials related to such
+ * distribution and use acknowledge that the software was developed
+ * by the University of California, Berkeley.  The name of the
+ * University may not be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+ * WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ */
 #include	"hdr.h"
 
 #define	LARGE	100000

--- a/v10/cmd/egrep/egrep.c
+++ b/v10/cmd/egrep/egrep.c
@@ -1,3 +1,20 @@
+/* Origin: /usr/src/ucb/grep/egrep.c */
+/*-
+ * Copyright (c) 1983 Regents of the University of California.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms are permitted
+ * provided that the above copyright notice and this paragraph are
+ * duplicated in all such forms and that any documentation,
+ * advertising materials, and other materials related to such
+ * distribution and use acknowledge that the software was developed
+ * by the University of California, Berkeley.  The name of the
+ * University may not be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+ * WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ */
 #include	"hdr.h"
 #include	"y.tab.h"
 

--- a/v10/cmd/egrep/main.c
+++ b/v10/cmd/egrep/main.c
@@ -1,3 +1,20 @@
+/* Origin: /usr/src/ucb/grep/main.c */
+/*-
+ * Copyright (c) 1983 Regents of the University of California.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms are permitted
+ * provided that the above copyright notice and this paragraph are
+ * duplicated in all such forms and that any documentation,
+ * advertising materials, and other materials related to such
+ * distribution and use acknowledge that the software was developed
+ * by the University of California, Berkeley.  The name of the
+ * University may not be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+ * WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ */
 #include	"hdr.h"
 
 #ifdef	DOSTATS

--- a/v10/cmd/fgrep.c
+++ b/v10/cmd/fgrep.c
@@ -1,3 +1,20 @@
+/* Origin: /usr/src/ucb/grep/fgrep.c */
+/*-
+ * Copyright (c) 1983 Regents of the University of California.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms are permitted
+ * provided that the above copyright notice and this paragraph are
+ * duplicated in all such forms and that any documentation,
+ * advertising materials, and other materials related to such
+ * distribution and use acknowledge that the software was developed
+ * by the University of California, Berkeley.  The name of the
+ * University may not be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+ * WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ */
 static char *sccsid = "@(#)fgrep.c	4.1 (Berkeley) 10/1/80";
 /*
  * fgrep -- print all lines containing any of a set of keywords

--- a/v10/cmd/grep.c
+++ b/v10/cmd/grep.c
@@ -1,3 +1,20 @@
+/* Origin: /usr/src/ucb/grep/grep.c */
+/*-
+ * Copyright (c) 1983 Regents of the University of California.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms are permitted
+ * provided that the above copyright notice and this paragraph are
+ * duplicated in all such forms and that any documentation,
+ * advertising materials, and other materials related to such
+ * distribution and use acknowledge that the software was developed
+ * by the University of California, Berkeley.  The name of the
+ * University may not be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+ * WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ */
 /*
  * grep -- print lines matching (or not matching) a pattern
  *

--- a/v10/cmd/sml/src/runtime/CompM68.mos
+++ b/v10/cmd/sml/src/runtime/CompM68.mos
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/sml/runtime/CompM68.mos */
+/*
+ * STANDARD ML OF NEW JERSEY COPYRIGHT NOTICE, LICENSE AND DISCLAIMER.
+ *
+ * Copyright 1989 by AT&T Bell Laboratories
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose and without fee is hereby granted,
+ * provided that the above copyright notice appear in all copies and that
+ * both the copyright notice and this permission notice and warranty
+ * disclaimer appear in supporting documentation, and that the name of
+ * AT&T Bell Laboratories or any AT&T entity not be used in advertising
+ * or publicity pertaining to distribution of the software without
+ * specific, written prior permission.
+ *
+ * AT&T disclaims all warranties with regard to this software, including
+ * all implied warranties of merchantability and fitness.  In no event
+ * shall AT&T be liable for any special, indirect or consequential
+ * damages or any damages whatsoever resulting from loss of use, data or
+ * profits, whether in an action of contract, negligence or other
+ * tortious action, arising out of or in connection with the use or
+ * performance of this software.
+ */
 mo/CoreFunc.mo
 mo/Initial.mo
 mo/Math.mo

--- a/v10/cmd/sml/src/runtime/CompNS32.mos
+++ b/v10/cmd/sml/src/runtime/CompNS32.mos
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/sml/runtime/CompNS32.mos */
+/*
+ * STANDARD ML OF NEW JERSEY COPYRIGHT NOTICE, LICENSE AND DISCLAIMER.
+ *
+ * Copyright 1989 by AT&T Bell Laboratories
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose and without fee is hereby granted,
+ * provided that the above copyright notice appear in all copies and that
+ * both the copyright notice and this permission notice and warranty
+ * disclaimer appear in supporting documentation, and that the name of
+ * AT&T Bell Laboratories or any AT&T entity not be used in advertising
+ * or publicity pertaining to distribution of the software without
+ * specific, written prior permission.
+ *
+ * AT&T disclaims all warranties with regard to this software, including
+ * all implied warranties of merchantability and fitness.  In no event
+ * shall AT&T be liable for any special, indirect or consequential
+ * damages or any damages whatsoever resulting from loss of use, data or
+ * profits, whether in an action of contract, negligence or other
+ * tortious action, arising out of or in connection with the use or
+ * performance of this software.
+ */
 mo/CoreFunc.mo
 mo/Initial.mo
 mo/Math.mo

--- a/v10/cmd/sml/src/runtime/CompSparc.mos
+++ b/v10/cmd/sml/src/runtime/CompSparc.mos
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/sml/runtime/CompSparc.mos */
+/*
+ * STANDARD ML OF NEW JERSEY COPYRIGHT NOTICE, LICENSE AND DISCLAIMER.
+ *
+ * Copyright 1989 by AT&T Bell Laboratories
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose and without fee is hereby granted,
+ * provided that the above copyright notice appear in all copies and that
+ * both the copyright notice and this permission notice and warranty
+ * disclaimer appear in supporting documentation, and that the name of
+ * AT&T Bell Laboratories or any AT&T entity not be used in advertising
+ * or publicity pertaining to distribution of the software without
+ * specific, written prior permission.
+ *
+ * AT&T disclaims all warranties with regard to this software, including
+ * all implied warranties of merchantability and fitness.  In no event
+ * shall AT&T be liable for any special, indirect or consequential
+ * damages or any damages whatsoever resulting from loss of use, data or
+ * profits, whether in an action of contract, negligence or other
+ * tortious action, arising out of or in connection with the use or
+ * performance of this software.
+ */
 mo/CoreFunc.mo
 mo/Initial.mo
 mo/Math.mo

--- a/v10/cmd/sml/src/runtime/CompVax.mos
+++ b/v10/cmd/sml/src/runtime/CompVax.mos
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/sml/runtime/CompVax.mos */
+/*
+ * STANDARD ML OF NEW JERSEY COPYRIGHT NOTICE, LICENSE AND DISCLAIMER.
+ *
+ * Copyright 1989 by AT&T Bell Laboratories
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose and without fee is hereby granted,
+ * provided that the above copyright notice appear in all copies and that
+ * both the copyright notice and this permission notice and warranty
+ * disclaimer appear in supporting documentation, and that the name of
+ * AT&T Bell Laboratories or any AT&T entity not be used in advertising
+ * or publicity pertaining to distribution of the software without
+ * specific, written prior permission.
+ *
+ * AT&T disclaims all warranties with regard to this software, including
+ * all implied warranties of merchantability and fitness.  In no event
+ * shall AT&T be liable for any special, indirect or consequential
+ * damages or any damages whatsoever resulting from loss of use, data or
+ * profits, whether in an action of contract, negligence or other
+ * tortious action, arising out of or in connection with the use or
+ * performance of this software.
+ */
 mo/CoreFunc.mo
 mo/Initial.mo
 mo/Math.mo

--- a/v10/cmd/sml/src/runtime/IntM68.mos
+++ b/v10/cmd/sml/src/runtime/IntM68.mos
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/sml/runtime/IntM68.mos */
+/*
+ * STANDARD ML OF NEW JERSEY COPYRIGHT NOTICE, LICENSE AND DISCLAIMER.
+ *
+ * Copyright 1989 by AT&T Bell Laboratories
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose and without fee is hereby granted,
+ * provided that the above copyright notice appear in all copies and that
+ * both the copyright notice and this permission notice and warranty
+ * disclaimer appear in supporting documentation, and that the name of
+ * AT&T Bell Laboratories or any AT&T entity not be used in advertising
+ * or publicity pertaining to distribution of the software without
+ * specific, written prior permission.
+ *
+ * AT&T disclaims all warranties with regard to this software, including
+ * all implied warranties of merchantability and fitness.  In no event
+ * shall AT&T be liable for any special, indirect or consequential
+ * damages or any damages whatsoever resulting from loss of use, data or
+ * profits, whether in an action of contract, negligence or other
+ * tortious action, arising out of or in connection with the use or
+ * performance of this software.
+ */
 mo/CoreFunc.mo
 mo/Initial.mo
 mo/Math.mo

--- a/v10/cmd/sml/src/runtime/IntNS32.mos
+++ b/v10/cmd/sml/src/runtime/IntNS32.mos
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/sml/runtime/IntNS32.mos */
+/*
+ * STANDARD ML OF NEW JERSEY COPYRIGHT NOTICE, LICENSE AND DISCLAIMER.
+ *
+ * Copyright 1989 by AT&T Bell Laboratories
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose and without fee is hereby granted,
+ * provided that the above copyright notice appear in all copies and that
+ * both the copyright notice and this permission notice and warranty
+ * disclaimer appear in supporting documentation, and that the name of
+ * AT&T Bell Laboratories or any AT&T entity not be used in advertising
+ * or publicity pertaining to distribution of the software without
+ * specific, written prior permission.
+ *
+ * AT&T disclaims all warranties with regard to this software, including
+ * all implied warranties of merchantability and fitness.  In no event
+ * shall AT&T be liable for any special, indirect or consequential
+ * damages or any damages whatsoever resulting from loss of use, data or
+ * profits, whether in an action of contract, negligence or other
+ * tortious action, arising out of or in connection with the use or
+ * performance of this software.
+ */
 mo/CoreFunc.mo
 mo/Initial.mo
 mo/Math.mo

--- a/v10/cmd/sml/src/runtime/IntNull.mos
+++ b/v10/cmd/sml/src/runtime/IntNull.mos
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/sml/runtime/IntNull.mos */
+/*
+ * STANDARD ML OF NEW JERSEY COPYRIGHT NOTICE, LICENSE AND DISCLAIMER.
+ *
+ * Copyright 1989 by AT&T Bell Laboratories
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose and without fee is hereby granted,
+ * provided that the above copyright notice appear in all copies and that
+ * both the copyright notice and this permission notice and warranty
+ * disclaimer appear in supporting documentation, and that the name of
+ * AT&T Bell Laboratories or any AT&T entity not be used in advertising
+ * or publicity pertaining to distribution of the software without
+ * specific, written prior permission.
+ *
+ * AT&T disclaims all warranties with regard to this software, including
+ * all implied warranties of merchantability and fitness.  In no event
+ * shall AT&T be liable for any special, indirect or consequential
+ * damages or any damages whatsoever resulting from loss of use, data or
+ * profits, whether in an action of contract, negligence or other
+ * tortious action, arising out of or in connection with the use or
+ * performance of this software.
+ */
 mo/CoreFunc.mo
 mo/Initial.mo
 mo/Math.mo

--- a/v10/cmd/sml/src/runtime/IntSparc.mos
+++ b/v10/cmd/sml/src/runtime/IntSparc.mos
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/sml/runtime/IntSparc.mos */
+/*
+ * STANDARD ML OF NEW JERSEY COPYRIGHT NOTICE, LICENSE AND DISCLAIMER.
+ *
+ * Copyright 1989 by AT&T Bell Laboratories
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose and without fee is hereby granted,
+ * provided that the above copyright notice appear in all copies and that
+ * both the copyright notice and this permission notice and warranty
+ * disclaimer appear in supporting documentation, and that the name of
+ * AT&T Bell Laboratories or any AT&T entity not be used in advertising
+ * or publicity pertaining to distribution of the software without
+ * specific, written prior permission.
+ *
+ * AT&T disclaims all warranties with regard to this software, including
+ * all implied warranties of merchantability and fitness.  In no event
+ * shall AT&T be liable for any special, indirect or consequential
+ * damages or any damages whatsoever resulting from loss of use, data or
+ * profits, whether in an action of contract, negligence or other
+ * tortious action, arising out of or in connection with the use or
+ * performance of this software.
+ */
 mo/CoreFunc.mo
 mo/Initial.mo
 mo/Math.mo

--- a/v10/cmd/sml/src/runtime/IntVax.mos
+++ b/v10/cmd/sml/src/runtime/IntVax.mos
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/sml/runtime/IntVax.mos */
+/*
+ * STANDARD ML OF NEW JERSEY COPYRIGHT NOTICE, LICENSE AND DISCLAIMER.
+ *
+ * Copyright 1989 by AT&T Bell Laboratories
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose and without fee is hereby granted,
+ * provided that the above copyright notice appear in all copies and that
+ * both the copyright notice and this permission notice and warranty
+ * disclaimer appear in supporting documentation, and that the name of
+ * AT&T Bell Laboratories or any AT&T entity not be used in advertising
+ * or publicity pertaining to distribution of the software without
+ * specific, written prior permission.
+ *
+ * AT&T disclaims all warranties with regard to this software, including
+ * all implied warranties of merchantability and fitness.  In no event
+ * shall AT&T be liable for any special, indirect or consequential
+ * damages or any damages whatsoever resulting from loss of use, data or
+ * profits, whether in an action of contract, negligence or other
+ * tortious action, arising out of or in connection with the use or
+ * performance of this software.
+ */
 mo/CoreFunc.mo
 mo/Initial.mo
 mo/Math.mo

--- a/v10/cmd/sml/src/runtime/descriptor.h
+++ b/v10/cmd/sml/src/runtime/descriptor.h
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/sml/runtime/descriptor.h */
+/*
+ * STANDARD ML OF NEW JERSEY COPYRIGHT NOTICE, LICENSE AND DISCLAIMER.
+ *
+ * Copyright 1989 by AT&T Bell Laboratories
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose and without fee is hereby granted,
+ * provided that the above copyright notice appear in all copies and that
+ * both the copyright notice and this permission notice and warranty
+ * disclaimer appear in supporting documentation, and that the name of
+ * AT&T Bell Laboratories or any AT&T entity not be used in advertising
+ * or publicity pertaining to distribution of the software without
+ * specific, written prior permission.
+ *
+ * AT&T disclaims all warranties with regard to this software, including
+ * all implied warranties of merchantability and fitness.  In no event
+ * shall AT&T be liable for any special, indirect or consequential
+ * damages or any damages whatsoever resulting from loss of use, data or
+ * profits, whether in an action of contract, negligence or other
+ * tortious action, arising out of or in connection with the use or
+ * performance of this software.
+ */
 /* needs tags.h */
 
 #define is_ptr(x) (!((int)(x)&1))

--- a/v10/cmd/sml/src/runtime/ml.h
+++ b/v10/cmd/sml/src/runtime/ml.h
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/sml/runtime/ml.h */
+/*
+ * STANDARD ML OF NEW JERSEY COPYRIGHT NOTICE, LICENSE AND DISCLAIMER.
+ *
+ * Copyright 1989 by AT&T Bell Laboratories
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose and without fee is hereby granted,
+ * provided that the above copyright notice appear in all copies and that
+ * both the copyright notice and this permission notice and warranty
+ * disclaimer appear in supporting documentation, and that the name of
+ * AT&T Bell Laboratories or any AT&T entity not be used in advertising
+ * or publicity pertaining to distribution of the software without
+ * specific, written prior permission.
+ *
+ * AT&T disclaims all warranties with regard to this software, including
+ * all implied warranties of merchantability and fitness.  In no event
+ * shall AT&T be liable for any special, indirect or consequential
+ * damages or any damages whatsoever resulting from loss of use, data or
+ * profits, whether in an action of contract, negligence or other
+ * tortious action, arising out of or in connection with the use or
+ * performance of this software.
+ */
 #define ML_INT(x) ((x)+(x)+1)
 #define ML_UNIT  1
 #define ML_NIL   1

--- a/v10/cmd/sml/src/runtime/prim.h
+++ b/v10/cmd/sml/src/runtime/prim.h
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/sml/runtime/prim.h */
+/*
+ * STANDARD ML OF NEW JERSEY COPYRIGHT NOTICE, LICENSE AND DISCLAIMER.
+ *
+ * Copyright 1989 by AT&T Bell Laboratories
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose and without fee is hereby granted,
+ * provided that the above copyright notice appear in all copies and that
+ * both the copyright notice and this permission notice and warranty
+ * disclaimer appear in supporting documentation, and that the name of
+ * AT&T Bell Laboratories or any AT&T entity not be used in advertising
+ * or publicity pertaining to distribution of the software without
+ * specific, written prior permission.
+ *
+ * AT&T disclaims all warranties with regard to this software, including
+ * all implied warranties of merchantability and fitness.  In no event
+ * shall AT&T be liable for any special, indirect or consequential
+ * damages or any damages whatsoever resulting from loss of use, data or
+ * profits, whether in an action of contract, negligence or other
+ * tortious action, arising out of or in connection with the use or
+ * performance of this software.
+ */
 #ifndef MIPS
 #define _div_e (_div_e0+4)
 #define _real_e (_real_e0+4)

--- a/v10/cmd/sml/src/runtime/prof.h
+++ b/v10/cmd/sml/src/runtime/prof.h
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/sml/runtime/prof.h */
+/*
+ * STANDARD ML OF NEW JERSEY COPYRIGHT NOTICE, LICENSE AND DISCLAIMER.
+ *
+ * Copyright 1989 by AT&T Bell Laboratories
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose and without fee is hereby granted,
+ * provided that the above copyright notice appear in all copies and that
+ * both the copyright notice and this permission notice and warranty
+ * disclaimer appear in supporting documentation, and that the name of
+ * AT&T Bell Laboratories or any AT&T entity not be used in advertising
+ * or publicity pertaining to distribution of the software without
+ * specific, written prior permission.
+ *
+ * AT&T disclaims all warranties with regard to this software, including
+ * all implied warranties of merchantability and fitness.  In no event
+ * shall AT&T be liable for any special, indirect or consequential
+ * damages or any damages whatsoever resulting from loss of use, data or
+ * profits, whether in an action of contract, negligence or other
+ * tortious action, arising out of or in connection with the use or
+ * performance of this software.
+ */
 /* modifications here must be duplicated in codegen/codegen.sml,
    vax/vaxprim.sml, and m68/m68prim.sml */
 #define ARRAYS 		0

--- a/v10/cmd/sml/src/runtime/tags.h
+++ b/v10/cmd/sml/src/runtime/tags.h
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/sml/runtime/tags.h */
+/*
+ * STANDARD ML OF NEW JERSEY COPYRIGHT NOTICE, LICENSE AND DISCLAIMER.
+ *
+ * Copyright 1989 by AT&T Bell Laboratories
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose and without fee is hereby granted,
+ * provided that the above copyright notice appear in all copies and that
+ * both the copyright notice and this permission notice and warranty
+ * disclaimer appear in supporting documentation, and that the name of
+ * AT&T Bell Laboratories or any AT&T entity not be used in advertising
+ * or publicity pertaining to distribution of the software without
+ * specific, written prior permission.
+ *
+ * AT&T disclaims all warranties with regard to this software, including
+ * all implied warranties of merchantability and fitness.  In no event
+ * shall AT&T be liable for any special, indirect or consequential
+ * damages or any damages whatsoever resulting from loss of use, data or
+ * profits, whether in an action of contract, negligence or other
+ * tortious action, arising out of or in connection with the use or
+ * performance of this software.
+ */
 /* tags.h
  *
  * This file has a corresponding ML structure tags embedded in structure Boot

--- a/v10/libF77/Version.c
+++ b/v10/libF77/Version.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/Version.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 static char junk[] = "\n@(#)LIBF77 VERSION 2.01 12 March 1993\n";
 
 /*

--- a/v10/libF77/abort_.c
+++ b/v10/libF77/abort_.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/abort_.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "stdio.h"
 #include "f2c.h"
 

--- a/v10/libF77/c_abs.c
+++ b/v10/libF77/c_abs.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/c_abs.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/c_cos.c
+++ b/v10/libF77/c_cos.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/c_cos.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/c_div.c
+++ b/v10/libF77/c_div.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/c_div.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/c_exp.c
+++ b/v10/libF77/c_exp.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/c_exp.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/c_log.c
+++ b/v10/libF77/c_log.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/c_log.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/c_sin.c
+++ b/v10/libF77/c_sin.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/c_sin.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/c_sqrt.c
+++ b/v10/libF77/c_sqrt.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/c_sqrt.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/cabs.c
+++ b/v10/libF77/cabs.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/cabs.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #ifdef KR_headers
 extern double sqrt();
 double f__cabs(real, imag) double real, imag;

--- a/v10/libF77/d_abs.c
+++ b/v10/libF77/d_abs.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/d_abs.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/d_acos.c
+++ b/v10/libF77/d_acos.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/d_acos.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/d_asin.c
+++ b/v10/libF77/d_asin.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/d_asin.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/d_atan.c
+++ b/v10/libF77/d_atan.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/d_atan.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/d_atn2.c
+++ b/v10/libF77/d_atn2.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/d_atn2.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/d_cnjg.c
+++ b/v10/libF77/d_cnjg.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/d_cnjg.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
  VOID

--- a/v10/libF77/d_cos.c
+++ b/v10/libF77/d_cos.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/d_cos.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/d_cosh.c
+++ b/v10/libF77/d_cosh.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/d_cosh.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/d_dim.c
+++ b/v10/libF77/d_dim.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/d_dim.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/d_exp.c
+++ b/v10/libF77/d_exp.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/d_exp.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/d_imag.c
+++ b/v10/libF77/d_imag.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/d_imag.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/d_int.c
+++ b/v10/libF77/d_int.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/d_int.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/d_lg10.c
+++ b/v10/libF77/d_lg10.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/d_lg10.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #define log10e 0.43429448190325182765

--- a/v10/libF77/d_log.c
+++ b/v10/libF77/d_log.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/d_log.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/d_mod.c
+++ b/v10/libF77/d_mod.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/d_mod.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/d_nint.c
+++ b/v10/libF77/d_nint.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/d_nint.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/d_prod.c
+++ b/v10/libF77/d_prod.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/d_prod.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/d_sign.c
+++ b/v10/libF77/d_sign.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/d_sign.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/d_sin.c
+++ b/v10/libF77/d_sin.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/d_sin.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/d_sinh.c
+++ b/v10/libF77/d_sinh.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/d_sinh.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/d_sqrt.c
+++ b/v10/libF77/d_sqrt.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/d_sqrt.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/d_tan.c
+++ b/v10/libF77/d_tan.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/d_tan.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/d_tanh.c
+++ b/v10/libF77/d_tanh.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/d_tanh.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/derf_.c
+++ b/v10/libF77/derf_.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/derf_.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/derfc_.c
+++ b/v10/libF77/derfc_.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/derfc_.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/ef1asc_.c
+++ b/v10/libF77/ef1asc_.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/ef1asc_.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /* EFL support routine to copy string b to string a */
 
 #include "f2c.h"

--- a/v10/libF77/ef1cmc_.c
+++ b/v10/libF77/ef1cmc_.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/ef1cmc_.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /* EFL support routine to compare two character strings */
 
 #include "f2c.h"

--- a/v10/libF77/erf_.c
+++ b/v10/libF77/erf_.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/erf_.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/erfc_.c
+++ b/v10/libF77/erfc_.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/erfc_.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/getarg_.c
+++ b/v10/libF77/getarg_.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/getarg_.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 /*

--- a/v10/libF77/getenv_.c
+++ b/v10/libF77/getenv_.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/getenv_.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 /*

--- a/v10/libF77/h_abs.c
+++ b/v10/libF77/h_abs.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/h_abs.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/h_dim.c
+++ b/v10/libF77/h_dim.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/h_dim.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/h_dnnt.c
+++ b/v10/libF77/h_dnnt.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/h_dnnt.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/h_indx.c
+++ b/v10/libF77/h_indx.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/h_indx.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/h_len.c
+++ b/v10/libF77/h_len.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/h_len.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/h_mod.c
+++ b/v10/libF77/h_mod.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/h_mod.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/h_nint.c
+++ b/v10/libF77/h_nint.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/h_nint.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/h_sign.c
+++ b/v10/libF77/h_sign.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/h_sign.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/hl_ge.c
+++ b/v10/libF77/hl_ge.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/hl_ge.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/hl_gt.c
+++ b/v10/libF77/hl_gt.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/hl_gt.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/hl_le.c
+++ b/v10/libF77/hl_le.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/hl_le.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/hl_lt.c
+++ b/v10/libF77/hl_lt.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/hl_lt.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/i_abs.c
+++ b/v10/libF77/i_abs.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/i_abs.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/i_dim.c
+++ b/v10/libF77/i_dim.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/i_dim.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/i_dnnt.c
+++ b/v10/libF77/i_dnnt.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/i_dnnt.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/i_indx.c
+++ b/v10/libF77/i_indx.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/i_indx.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/i_len.c
+++ b/v10/libF77/i_len.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/i_len.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/i_mod.c
+++ b/v10/libF77/i_mod.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/i_mod.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/i_nint.c
+++ b/v10/libF77/i_nint.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/i_nint.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/i_sign.c
+++ b/v10/libF77/i_sign.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/i_sign.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/iargc_.c
+++ b/v10/libF77/iargc_.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/iargc_.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/l_ge.c
+++ b/v10/libF77/l_ge.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/l_ge.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/l_gt.c
+++ b/v10/libF77/l_gt.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/l_gt.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/l_le.c
+++ b/v10/libF77/l_le.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/l_le.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/l_lt.c
+++ b/v10/libF77/l_lt.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/l_lt.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/main.c
+++ b/v10/libF77/main.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/main.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /* STARTUP PROCEDURE FOR UNIX FORTRAN PROGRAMS */
 
 #include "stdio.h"

--- a/v10/libF77/notused/mclock_.c
+++ b/v10/libF77/notused/mclock_.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/mclock_.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 long int  mclock_()
   {
   int  buf[6];

--- a/v10/libF77/notused/outstr_.c
+++ b/v10/libF77/notused/outstr_.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/outstr_.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include <stdio.h>
 
 /* print a character string */

--- a/v10/libF77/notused/subout.c
+++ b/v10/libF77/notused/subout.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/subout.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include <stdio.h>
 
 subout(varn, offset, procn, line)

--- a/v10/libF77/old/Version.c
+++ b/v10/libF77/old/Version.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/Version.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 static char junk[] = "\n@(#)LIBF77 VERSION 2.00  11 JUNE 1980\n";
 
 /*

--- a/v10/libF77/old/hl_ge.c
+++ b/v10/libF77/old/hl_ge.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/hl_ge.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 short l_ge(a,b,la,lb)
 char *a, *b;
 long int la, lb;

--- a/v10/libF77/old/hl_gt.c
+++ b/v10/libF77/old/hl_gt.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/hl_gt.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 short l_gt(a,b,la,lb)
 char *a, *b;
 long int la, lb;

--- a/v10/libF77/old/hl_le.c
+++ b/v10/libF77/old/hl_le.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/hl_le.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 short l_le(a,b,la,lb)
 char *a, *b;
 long int la, lb;

--- a/v10/libF77/old/hl_lt.c
+++ b/v10/libF77/old/hl_lt.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/hl_lt.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 short l_lt(a,b,la,lb)
 char *a, *b;
 long int la, lb;

--- a/v10/libF77/old/main.c
+++ b/v10/libF77/old/main.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/main.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /* STARTUP PROCEDURE FOR UNIX FORTRAN PROGRAMS */
 
 #include <stdio.h>

--- a/v10/libF77/old/s_cat.c
+++ b/v10/libF77/old/s_cat.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/s_cat.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 s_cat(lp, rpp, rnp, np, ll)
 char *lp, *rpp[];
 long int rnp[], *np, ll;

--- a/v10/libF77/old/s_paus.c
+++ b/v10/libF77/old/s_paus.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/s_paus.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include <stdio.h>
 #define PAUSESIG 15
 

--- a/v10/libF77/old/z_sqrt.c
+++ b/v10/libF77/old/z_sqrt.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/z_sqrt.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 VOID z_sqrt(r, z)

--- a/v10/libF77/pow_ci.c
+++ b/v10/libF77/pow_ci.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/pow_ci.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/pow_dd.c
+++ b/v10/libF77/pow_dd.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/pow_dd.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/pow_di.c
+++ b/v10/libF77/pow_di.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/pow_di.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/pow_hh.c
+++ b/v10/libF77/pow_hh.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/pow_hh.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/pow_ii.c
+++ b/v10/libF77/pow_ii.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/pow_ii.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/pow_qq.c
+++ b/v10/libF77/pow_qq.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/pow_qq.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/pow_ri.c
+++ b/v10/libF77/pow_ri.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/pow_ri.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/pow_zi.c
+++ b/v10/libF77/pow_zi.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/pow_zi.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/pow_zz.c
+++ b/v10/libF77/pow_zz.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/pow_zz.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/r_abs.c
+++ b/v10/libF77/r_abs.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/r_abs.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/r_acos.c
+++ b/v10/libF77/r_acos.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/r_acos.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/r_asin.c
+++ b/v10/libF77/r_asin.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/r_asin.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/r_atan.c
+++ b/v10/libF77/r_atan.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/r_atan.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/r_atn2.c
+++ b/v10/libF77/r_atn2.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/r_atn2.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/r_cnjg.c
+++ b/v10/libF77/r_cnjg.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/r_cnjg.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/r_cos.c
+++ b/v10/libF77/r_cos.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/r_cos.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/r_cosh.c
+++ b/v10/libF77/r_cosh.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/r_cosh.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/r_dim.c
+++ b/v10/libF77/r_dim.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/r_dim.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/r_exp.c
+++ b/v10/libF77/r_exp.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/r_exp.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/r_imag.c
+++ b/v10/libF77/r_imag.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/r_imag.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/r_int.c
+++ b/v10/libF77/r_int.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/r_int.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/r_lg10.c
+++ b/v10/libF77/r_lg10.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/r_lg10.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #define log10e 0.43429448190325182765

--- a/v10/libF77/r_log.c
+++ b/v10/libF77/r_log.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/r_log.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/r_mod.c
+++ b/v10/libF77/r_mod.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/r_mod.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/r_nint.c
+++ b/v10/libF77/r_nint.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/r_nint.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/r_sign.c
+++ b/v10/libF77/r_sign.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/r_sign.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/r_sin.c
+++ b/v10/libF77/r_sin.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/r_sin.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/r_sinh.c
+++ b/v10/libF77/r_sinh.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/r_sinh.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/r_sqrt.c
+++ b/v10/libF77/r_sqrt.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/r_sqrt.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/r_tan.c
+++ b/v10/libF77/r_tan.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/r_tan.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/r_tanh.c
+++ b/v10/libF77/r_tanh.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/r_tanh.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/s_cat.c
+++ b/v10/libF77/s_cat.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/s_cat.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/s_cmp.c
+++ b/v10/libF77/s_cmp.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/s_cmp.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 /* compare two strings */

--- a/v10/libF77/s_copy.c
+++ b/v10/libF77/s_copy.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/s_copy.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 /* assign strings:  a = b */

--- a/v10/libF77/s_paus.c
+++ b/v10/libF77/s_paus.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/s_paus.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "stdio.h"
 #include "f2c.h"
 #define PAUSESIG 15

--- a/v10/libF77/s_rnge.c
+++ b/v10/libF77/s_rnge.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/s_rnge.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "stdio.h"
 #include "f2c.h"
 

--- a/v10/libF77/s_stop.c
+++ b/v10/libF77/s_stop.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/s_stop.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "stdio.h"
 #include "f2c.h"
 

--- a/v10/libF77/sig_die.c
+++ b/v10/libF77/sig_die.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/sig_die.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "stdio.h"
 #include "signal.h"
 

--- a/v10/libF77/signal_.c
+++ b/v10/libF77/signal_.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/signal_.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/system_.c
+++ b/v10/libF77/system_.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/system_.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /* f77 interface to system routine */
 
 #include "f2c.h"

--- a/v10/libF77/z_abs.c
+++ b/v10/libF77/z_abs.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/z_abs.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/z_cos.c
+++ b/v10/libF77/z_cos.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/z_cos.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/z_div.c
+++ b/v10/libF77/z_div.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/z_div.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/z_exp.c
+++ b/v10/libF77/z_exp.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/z_exp.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/z_log.c
+++ b/v10/libF77/z_log.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/z_log.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/z_sin.c
+++ b/v10/libF77/z_sin.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/z_sin.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libF77/z_sqrt.c
+++ b/v10/libF77/z_sqrt.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libF77/z_sqrt.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef KR_headers

--- a/v10/libI77/Version.c
+++ b/v10/libI77/Version.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/Version.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 static char junk[] = "\n@(#) LIBI77 VERSION pjw,dmg-mods 23 June 1993\n";
 
 /*

--- a/v10/libI77/backspace.c
+++ b/v10/libI77/backspace.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/backspace.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #ifdef KR_headers

--- a/v10/libI77/close.c
+++ b/v10/libI77/close.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/close.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #ifdef KR_headers

--- a/v10/libI77/d/Version.c
+++ b/v10/libI77/d/Version.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/Version.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 1c1
 < static char junk[] = "\n@(#) LIBI77 VERSION pjw,dmg-mods 1 Feb. 1993\n";
 ---

--- a/v10/libI77/d/close.c
+++ b/v10/libI77/d/close.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/close.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 9a10,14
 > #ifdef NON_UNIX_STDIO
 > #ifndef unlink

--- a/v10/libI77/d/dfe.c
+++ b/v10/libI77/d/dfe.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/dfe.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 32a33,35
 > #ifdef __cplusplus
 > 	return 0;

--- a/v10/libI77/d/due.c
+++ b/v10/libI77/d/due.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/due.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 13c13
 < 	f__recpos=f__sequential=f__formatted=0;
 ---

--- a/v10/libI77/d/endfile.c
+++ b/v10/libI77/d/endfile.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/endfile.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 4d3
 < #include "fcntl.h"
 6,8d4

--- a/v10/libI77/d/err.c
+++ b/v10/libI77/d/err.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/err.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 1c1
 < #ifndef MSDOS
 ---

--- a/v10/libI77/d/fmt.c
+++ b/v10/libI77/d/fmt.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/fmt.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 416,417c416,419
 < 		if((n=(*f__doed)(p,ptr,len))>0) err(f__elist->cierr,errno,"fmt");
 < 		if(n<0) err(f__elist->ciend,(EOF),"fmt");

--- a/v10/libI77/d/fmtlib.c
+++ b/v10/libI77/d/fmtlib.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/fmtlib.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 3,5d2
 < #ifdef __cplusplus
 < extern "C" {

--- a/v10/libI77/d/iio.c
+++ b/v10/libI77/d/iio.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/iio.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 15a16,18
 > #ifdef __cplusplus
 > 	return 0;

--- a/v10/libI77/d/ilnw.c
+++ b/v10/libI77/d/ilnw.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/ilnw.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 44a45
 >  integer
 59a61

--- a/v10/libI77/d/inquire.c
+++ b/v10/libI77/d/inquire.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/inquire.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 23c23
 < #ifdef MSDOS
 ---

--- a/v10/libI77/d/lread.c
+++ b/v10/libI77/d/lread.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/lread.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 67c67
 < 		l_eof = f__curunit->uend = 1;
 ---

--- a/v10/libI77/d/lwrite.c
+++ b/v10/libI77/d/lwrite.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/lwrite.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 5c5
 < int L_len;
 ---

--- a/v10/libI77/d/open.c
+++ b/v10/libI77/d/open.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/open.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 6d5
 < #include "fcntl.h"
 8,11d6

--- a/v10/libI77/d/rsli.c
+++ b/v10/libI77/d/rsli.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/rsli.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 3a4
 > #include "fmt.h" /* for f__doend */
 12c13

--- a/v10/libI77/d/rsne.c
+++ b/v10/libI77/d/rsne.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/rsne.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 179c179
 < 		err(f__elist->cierr, ch, "namelist read");
 ---

--- a/v10/libI77/d/sig_die.c
+++ b/v10/libI77/d/sig_die.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/sig_die.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 8,10d7
 < #ifdef __cplusplus
 < extern "C" {

--- a/v10/libI77/d/uio.c
+++ b/v10/libI77/d/uio.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/uio.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 13c13
 < 		f__recpos += *number * len;
 ---

--- a/v10/libI77/d/util.c
+++ b/v10/libI77/d/util.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/util.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 1c1
 < #ifndef MSDOS
 ---

--- a/v10/libI77/d/wref.c
+++ b/v10/libI77/d/wref.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/wref.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 48c48
 < 		signspace = f__cplus;
 ---

--- a/v10/libI77/d/wrtfmt.c
+++ b/v10/libI77/d/wrtfmt.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/wrtfmt.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 115c115
 < 	for(;; s += i, w1 += 2)
 ---

--- a/v10/libI77/d/wsne.c
+++ b/v10/libI77/d/wsne.c
@@ -1,2 +1,25 @@
+/* Origin: /usr/src/libI77/wsne.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 13d12
 < 	extern integer e_wsle(Void);

--- a/v10/libI77/d/xwsne.c
+++ b/v10/libI77/d/xwsne.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/xwsne.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 5a6,12
 >  static VOID
 > nl_donewrec(Void)

--- a/v10/libI77/dfe.c
+++ b/v10/libI77/dfe.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/dfe.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #include "fmt.h"

--- a/v10/libI77/dolio.c
+++ b/v10/libI77/dolio.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/dolio.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 #ifdef __cplusplus

--- a/v10/libI77/due.c
+++ b/v10/libI77/due.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/due.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 

--- a/v10/libI77/endfile.c
+++ b/v10/libI77/endfile.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/endfile.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #include "sys/types.h"

--- a/v10/libI77/err.c
+++ b/v10/libI77/err.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/err.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #ifndef NON_UNIX_STDIO
 #include "sys/types.h"
 #include "sys/stat.h"

--- a/v10/libI77/fmt.c
+++ b/v10/libI77/fmt.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/fmt.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #include "fmt.h"

--- a/v10/libI77/fmtlib.c
+++ b/v10/libI77/fmtlib.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/fmtlib.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)fmtlib.c	1.2	*/
 #define MAXINTLENGTH 23
 #ifdef KR_headers

--- a/v10/libI77/iio.c
+++ b/v10/libI77/iio.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/iio.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #include "fmt.h"

--- a/v10/libI77/ilnw.c
+++ b/v10/libI77/ilnw.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/ilnw.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #include "lio.h"

--- a/v10/libI77/inquire.c
+++ b/v10/libI77/inquire.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/inquire.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #ifdef KR_headers

--- a/v10/libI77/lread.c
+++ b/v10/libI77/lread.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/lread.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #include "fmt.h"

--- a/v10/libI77/lwrite.c
+++ b/v10/libI77/lwrite.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/lwrite.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #include "fmt.h"

--- a/v10/libI77/notused/ctest.c
+++ b/v10/libI77/notused/ctest.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/ctest.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)ctest.c	1.2	*/
 #include "stdio.h"
 char buf[256];

--- a/v10/libI77/notused/data.c
+++ b/v10/libI77/notused/data.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/data.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)data.c	2.5	*/
 /*LINTLIBRARY*/
 #include <stdio.h>

--- a/v10/libI77/notused/dballoc.c
+++ b/v10/libI77/notused/dballoc.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/dballoc.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)dballoc.c	1.2	*/
 #define debug YES
 #ifndef debug

--- a/v10/libI77/notused/ecvt.c
+++ b/v10/libI77/notused/ecvt.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/ecvt.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)ecvt.c	2.7	*/
 /*	3.0 SID #	1.2	*/
 /*LINTLIBRARY*/

--- a/v10/libI77/notused/filbuf.c
+++ b/v10/libI77/notused/filbuf.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/filbuf.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)filbuf.c	2.1	*/
 /*	3.0 SID #	1.2	*/
 /*LINTLIBRARY*/

--- a/v10/libI77/notused/findiop.c
+++ b/v10/libI77/notused/findiop.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/findiop.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)findiop.c	1.2	*/
 /*	3.0 SID #	1.2	*/
 /*LINTLIBRARY*/

--- a/v10/libI77/notused/flsbuf.c
+++ b/v10/libI77/notused/flsbuf.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/flsbuf.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)flsbuf.c	2.8	*/
 /*LINTLIBRARY*/
 #include <stdio.h>

--- a/v10/libI77/notused/fopen.5.c
+++ b/v10/libI77/notused/fopen.5.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/fopen.5.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)fopen.c	1.8	*/
 /*LINTLIBRARY*/
 #include "stdio.h"

--- a/v10/libI77/notused/fopen.c
+++ b/v10/libI77/notused/fopen.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/fopen.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)fopen.c	1.8	*/
 /*LINTLIBRARY*/
 #include "stdio.h"

--- a/v10/libI77/notused/fputs.c
+++ b/v10/libI77/notused/fputs.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/fputs.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*      <@(#)fputs.c	3.5>	*/
 /*LINTLIBRARY*/
 /*

--- a/v10/libI77/notused/fread.c
+++ b/v10/libI77/notused/fread.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/fread.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)fread.c	3.11	*/
 /*LINTLIBRARY*/
 /*

--- a/v10/libI77/notused/fseek.c
+++ b/v10/libI77/notused/fseek.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/fseek.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)fseek.c	1.3	*/
 /*	3.0 SID #	1.2	*/
 /*LINTLIBRARY*/

--- a/v10/libI77/notused/ftell.c
+++ b/v10/libI77/notused/ftell.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/ftell.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)ftell.c	1.2	*/
 /*	3.0 SID #	1.2	*/
 /*LINTLIBRARY*/

--- a/v10/libI77/notused/ftest.c
+++ b/v10/libI77/notused/ftest.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/ftest.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)ftest.c	1.2	*/
 #include "fio.h"
 #define FLOAT double

--- a/v10/libI77/notused/fwrite.c
+++ b/v10/libI77/notused/fwrite.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/fwrite.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)fwrite.c	3.6	*/
 /*LINTLIBRARY*/
 /*

--- a/v10/libI77/notused/lib.c
+++ b/v10/libI77/notused/lib.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/lib.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)lib.c	1.2	*/
 #include "fio.h"
 setcilist(x,u,fmt,rec,xerr,end) cilist *x;

--- a/v10/libI77/notused/ltostr.c
+++ b/v10/libI77/notused/ltostr.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/ltostr.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)ltostr.c	1.1	*/
 /*
  *	ltostr -- convert long to decimal string

--- a/v10/libI77/notused/nio.c
+++ b/v10/libI77/notused/nio.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/nio.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)nio.c	1.1	*/
 #include <stdio.h>
 #include <ctype.h>

--- a/v10/libI77/notused/puts.c
+++ b/v10/libI77/notused/puts.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/puts.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)puts.c	3.3	*/
 /*LINTLIBRARY*/
 /*

--- a/v10/libI77/notused/rew.c
+++ b/v10/libI77/notused/rew.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/rew.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)rew.c	1.2	*/
 /*	3.0 SID #	1.2	*/
 /*LINTLIBRARY*/

--- a/v10/libI77/notused/setbuf.c
+++ b/v10/libI77/notused/setbuf.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/setbuf.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)setbuf.c	2.2	*/
 /*	3.0 SID #	1.2	*/
 /*LINTLIBRARY*/

--- a/v10/libI77/notused/setvbuf.c
+++ b/v10/libI77/notused/setvbuf.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/setvbuf.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)setvbuf.c	1.2			*/
 /*LINTLIBRARY*/
 #include "stdio.h"

--- a/v10/libI77/notused/stest.c
+++ b/v10/libI77/notused/stest.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/stest.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)stest.c	1.2	*/
 #include "fio.h"
 #define out(a,b) {n=b;if(n==0) fprintf(stderr,"%s:%d\n",a,errno);else \

--- a/v10/libI77/old/Version.c
+++ b/v10/libI77/old/Version.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/Version.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)Version.c	1.3	*/
 /*	3.0 SID #	1.2	*/
 static char junk[] = "\n@(#) LIBI77 VERSION pjw-mods   5 NOVEMBER 1983\n";

--- a/v10/libI77/old/backspace.c
+++ b/v10/libI77/old/backspace.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/backspace.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)backspace.c	1.3	*/
 /*	3.0 SID #	1.2	*/
 #include "fio.h"

--- a/v10/libI77/old/close.c
+++ b/v10/libI77/old/close.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/close.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)close.c	1.2	*/
 /*	3.0 SID #	1.2	*/
 #include "fio.h"

--- a/v10/libI77/old/dfe.c
+++ b/v10/libI77/old/dfe.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/dfe.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)dfe.c	1.2	*/
 /*	3.0 SID #	1.2	*/
 #include "fio.h"

--- a/v10/libI77/old/due.c
+++ b/v10/libI77/old/due.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/due.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)due.c	1.2	*/
 /*	3.0 SID #	1.2	*/
 #include "fio.h"

--- a/v10/libI77/old/endfile.c
+++ b/v10/libI77/old/endfile.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/endfile.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)endfile.c	1.3	*/
 
 #include "fio.h"

--- a/v10/libI77/old/err.c
+++ b/v10/libI77/old/err.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/err.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)err.c	1.3	*/
 /*	3.0 SID #	1.3	*/
 #include <sys/types.h>

--- a/v10/libI77/old/inquire.c
+++ b/v10/libI77/old/inquire.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/inquire.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)inquire.c	1.3	*/
 
 #include "fio.h"

--- a/v10/libI77/old/lio.c
+++ b/v10/libI77/old/lio.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/lio.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)lio.c	1.3	*/
 /*	3.0 SID #	1.3	*/
 #include "fio.h"

--- a/v10/libI77/old/lread.c
+++ b/v10/libI77/old/lread.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/lread.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)lread.c	1.3	*/
 
 #include "fio.h"

--- a/v10/libI77/old/open.c
+++ b/v10/libI77/old/open.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/open.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)open.c	1.4	*/
 
 #include	"sys/types.h"

--- a/v10/libI77/old/rdfmt.c
+++ b/v10/libI77/old/rdfmt.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/rdfmt.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)rdfmt.c	1.4	*/
 
 #include "fio.h"

--- a/v10/libI77/old/rewind.c
+++ b/v10/libI77/old/rewind.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/rewind.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)rewind.c	1.2	*/
 /*	3.0 SID #	1.2	*/
 #include "fio.h"

--- a/v10/libI77/old/rsfe.c
+++ b/v10/libI77/old/rsfe.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/rsfe.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)rsfe.c	1.2	*/
 /*	3.0 SID #	1.2	*/
 /* read sequential formatted external */

--- a/v10/libI77/old/sfe.c
+++ b/v10/libI77/old/sfe.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/sfe.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)sfe.c	1.2	*/
 /*	3.0 SID #	1.2	*/
 /* sequential formatted external common routines*/

--- a/v10/libI77/old/sue.c
+++ b/v10/libI77/old/sue.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/sue.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)sue.c	1.2	*/
 /*	3.0 SID #	1.2	*/
 #include "fio.h"

--- a/v10/libI77/old/uio.c
+++ b/v10/libI77/old/uio.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/uio.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 int reclen;

--- a/v10/libI77/old/wref0.c
+++ b/v10/libI77/old/wref0.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/wref0.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "fio.h"
 #include "fmt.h"
 

--- a/v10/libI77/old/wrtfmt.c
+++ b/v10/libI77/old/wrtfmt.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/wrtfmt.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)wrtfmt.c	1.3	*/
 /*	3.0 SID #	1.2	*/
 #include "fio.h"

--- a/v10/libI77/old/wsfe.c
+++ b/v10/libI77/old/wsfe.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/wsfe.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)wsfe.c	1.2	*/
 /*	3.0 SID #	1.2	*/
 /*write sequential formatted external*/

--- a/v10/libI77/old1/Version.c
+++ b/v10/libI77/old1/Version.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/Version.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 static char junk[] = "\n@(#) LIBI77 VERSION pjw,dmg-mods 1 Feb. 1993\n";
 
 /*

--- a/v10/libI77/old1/close.c
+++ b/v10/libI77/old1/close.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/close.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #ifdef KR_headers

--- a/v10/libI77/old1/dfe.c
+++ b/v10/libI77/old1/dfe.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/dfe.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #include "fmt.h"

--- a/v10/libI77/old1/due.c
+++ b/v10/libI77/old1/due.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/due.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 

--- a/v10/libI77/old1/endfile.c
+++ b/v10/libI77/old1/endfile.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/endfile.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #include "sys/types.h"

--- a/v10/libI77/old1/err.c
+++ b/v10/libI77/old1/err.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/err.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #ifndef MSDOS
 #include "sys/types.h"
 #include "sys/stat.h"

--- a/v10/libI77/old1/fmt.c
+++ b/v10/libI77/old1/fmt.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/fmt.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #include "fmt.h"

--- a/v10/libI77/old1/fmtlib.c
+++ b/v10/libI77/old1/fmtlib.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/fmtlib.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*	@(#)fmtlib.c	1.2	*/
 #define MAXINTLENGTH 23
 #ifdef __cplusplus

--- a/v10/libI77/old1/iio.c
+++ b/v10/libI77/old1/iio.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/iio.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #include "fmt.h"

--- a/v10/libI77/old1/ilnw.c
+++ b/v10/libI77/old1/ilnw.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/ilnw.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #include "lio.h"

--- a/v10/libI77/old1/inquire.c
+++ b/v10/libI77/old1/inquire.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/inquire.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #ifdef KR_headers

--- a/v10/libI77/old1/lread.c
+++ b/v10/libI77/old1/lread.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/lread.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #include "fmt.h"

--- a/v10/libI77/old1/lwrite.c
+++ b/v10/libI77/old1/lwrite.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/lwrite.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #include "fmt.h"

--- a/v10/libI77/old1/open.c
+++ b/v10/libI77/old1/open.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/open.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "sys/types.h"
 #include "sys/stat.h"
 #include "f2c.h"

--- a/v10/libI77/old1/rsli.c
+++ b/v10/libI77/old1/rsli.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/rsli.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #include "lio.h"

--- a/v10/libI77/old1/rsne.c
+++ b/v10/libI77/old1/rsne.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/rsne.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #include "lio.h"

--- a/v10/libI77/old1/sig_die.c
+++ b/v10/libI77/old1/sig_die.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/sig_die.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "stdio.h"
 #include "signal.h"
 

--- a/v10/libI77/old1/uio.c
+++ b/v10/libI77/old1/uio.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/uio.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 uiolen f__reclen;

--- a/v10/libI77/old1/util.c
+++ b/v10/libI77/old1/util.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/util.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #ifndef MSDOS
 #include "sys/types.h"
 #include "sys/stat.h"

--- a/v10/libI77/old1/wref.c
+++ b/v10/libI77/old1/wref.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/wref.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #include "fmt.h"

--- a/v10/libI77/old1/wrtfmt.c
+++ b/v10/libI77/old1/wrtfmt.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/wrtfmt.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #include "fmt.h"

--- a/v10/libI77/old1/wsne.c
+++ b/v10/libI77/old1/wsne.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/wsne.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #include "lio.h"

--- a/v10/libI77/old1/xwsne.c
+++ b/v10/libI77/old1/xwsne.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/xwsne.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #include "lio.h"

--- a/v10/libI77/open.c
+++ b/v10/libI77/open.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/open.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "sys/types.h"
 #include "sys/stat.h"
 #include "f2c.h"

--- a/v10/libI77/rdfmt.c
+++ b/v10/libI77/rdfmt.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/rdfmt.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #include "fmt.h"

--- a/v10/libI77/rewind.c
+++ b/v10/libI77/rewind.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/rewind.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #ifdef KR_headers

--- a/v10/libI77/rsfe.c
+++ b/v10/libI77/rsfe.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/rsfe.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /* read sequential formatted external */
 #include "f2c.h"
 #include "fio.h"

--- a/v10/libI77/rsli.c
+++ b/v10/libI77/rsli.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/rsli.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #include "lio.h"

--- a/v10/libI77/rsne.c
+++ b/v10/libI77/rsne.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/rsne.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #include "lio.h"

--- a/v10/libI77/sfe.c
+++ b/v10/libI77/sfe.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/sfe.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /* sequential formatted external common routines*/
 #include "f2c.h"
 #include "fio.h"

--- a/v10/libI77/sig_die.c
+++ b/v10/libI77/sig_die.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/sig_die.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "stdio.h"
 #include "signal.h"
 

--- a/v10/libI77/sue.c
+++ b/v10/libI77/sue.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/sue.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 extern uiolen f__reclen;

--- a/v10/libI77/typesize.c
+++ b/v10/libI77/typesize.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/typesize.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 
 ftnlen f__typesize[] = { 0, 0, sizeof(shortint), sizeof(integer),

--- a/v10/libI77/uio.c
+++ b/v10/libI77/uio.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/uio.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 uiolen f__reclen;

--- a/v10/libI77/util.c
+++ b/v10/libI77/util.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/util.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #ifndef NON_UNIX_STDIO
 #include "sys/types.h"
 #include "sys/stat.h"

--- a/v10/libI77/wref.c
+++ b/v10/libI77/wref.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/wref.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #include "fmt.h"

--- a/v10/libI77/wrtfmt.c
+++ b/v10/libI77/wrtfmt.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/wrtfmt.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #include "fmt.h"

--- a/v10/libI77/wsfe.c
+++ b/v10/libI77/wsfe.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/wsfe.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 /*write sequential formatted external*/
 #include "f2c.h"
 #include "fio.h"

--- a/v10/libI77/wsle.c
+++ b/v10/libI77/wsle.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/wsle.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #include "fmt.h"

--- a/v10/libI77/wsne.c
+++ b/v10/libI77/wsne.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/wsne.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #include "lio.h"

--- a/v10/libI77/xwsne.c
+++ b/v10/libI77/xwsne.c
@@ -1,3 +1,26 @@
+/* Origin: /usr/src/libI77/xwsne.c */
+/*
+ * Copyright 1990, 1991, 1992, 1993
+ *      AT&T Bell Laboratories and Bellcore.
+ *
+ * Permission to use, copy, modify, and distribute this software
+ * and its documentation for any purpose and without fee is hereby
+ * granted, provided that the above copyright notice appear in all
+ * copies and that both the copyright notice and this permission
+ * notice and warranty disclaimer appear in supporting documentation,
+ * and that the names of AT&T Bell Laboratories or Bellcore or any of
+ * their entities not be used in advertising or publicity pertaining to
+ * distribution of the software without specific, written prior permission.
+ *
+ * AT&T and Bellcore disclaim all warranties with regard to this
+ * software, including all implied warranties of merchantability
+ * and fitness.  In no event shall AT&T or Bellcore be liable for
+ * any special, indirect or consequential damages or any damages
+ * whatsoever resulting from loss of use, data or profits, whether
+ * in an action of contract, negligence or other tortious action,
+ * arising out of or in connection with the use or performance of
+ * this software.
+ */
 #include "f2c.h"
 #include "fio.h"
 #include "lio.h"


### PR DESCRIPTION
## Summary
- add f2c runtime license to libF77 and libI77 sources
- add SML/NJ runtime license headers
- add BSD license to grep utilities

## Testing
- `git status --short`
