### PR TITLE
Add MIT license header template and update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+/* Portions modified in 2024 under the MIT License. */
+
 This repository contains portions of the Research UNIX Version 10 source
 code and documentation originally developed at AT&T Bell Laboratories.
 
@@ -6,3 +8,5 @@ made available here for historical reference.  The original software was
 never formally released for general redistribution, and the current
 redistribution rights are unclear.  Permission from the original rights
 holders may be required for any use beyond personal study.
+
+New contributions to this repository are provided under the MIT License unless otherwise stated. See tools/mit-header.txt for the standard license header.

--- a/tools/mit-header.txt
+++ b/tools/mit-header.txt
@@ -1,0 +1,23 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 The Research UNIX 10 Restoration Project
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */


### PR DESCRIPTION
## Summary
- create MIT license header template for new contributions
- update LICENSE with MIT notice

## Testing
- `make check` *(fails: unrecognized command-line option '-std=c23')*