### PR TITLE
Add SMP lock for IP fragment reassembly

### DIFF
--- a/v10/sys/sys/inet/ip_var.h
+++ b/v10/sys/sys/inet/ip_var.h
@@ -109,6 +109,11 @@ extern struct ipif *ip_ifwithaddr(), *ip_ifonnetof();
 #define IP_BODY_LIMIT 8192
 #define IP_MSG_LIMIT (sizeof(struct ipovly) + IP_BODY_LIMIT)
 
+#ifdef SMP_ENABLED
+#include "../../../ipc/h/spinlock.h"
+extern spinlock_t ipq_lock;
+#endif
+
 /* an ip routing record */
 struct ip_route{
 	long time;		/* time of last access */


### PR DESCRIPTION
## Summary
- declare `ipq_lock` spin lock in `ip_var.h`
- create `ipq_lock` definition in `ip_input.c`
- guard IP fragment queue manipulation with the new lock

## Testing
- `make` (fails: unrecognized option `-std=c23`)