### PR TITLE
Add runtime cache line size detection

### DIFF
--- a/v10/ipc/h/spinlock.h
+++ b/v10/ipc/h/spinlock.h
@@ -16,9 +16,11 @@
 #define SPINLOCK_CACHE_LINE_SIZE 64
 #endif
 
+unsigned spinlock_runtime_cache_line_size(void);
+
 static inline unsigned spinlock_cache_line_size(void)
 {
-    return SPINLOCK_CACHE_LINE_SIZE;
+    return spinlock_runtime_cache_line_size();
 }
 
 #ifndef CACHE_LINE_SIZE

--- a/v10/ipc/spinlock.c
+++ b/v10/ipc/spinlock.c
@@ -30,3 +30,64 @@ void spin_unlock(spinlock_t *lock)
 }
 #endif
 #endif /* SMP_ENABLED */
+
+static unsigned detected_cache_line_size;
+
+#if defined(__x86_64__) || defined(__i386__)
+static void cpuid(unsigned int leaf, unsigned int subleaf,
+                  unsigned int *a, unsigned int *b,
+                  unsigned int *c, unsigned int *d)
+{
+#if defined(__i386__) && defined(__PIC__)
+    __asm__ volatile("xchgl %%ebx, %1; cpuid; xchgl %%ebx, %1"
+                     : "=a"(*a), "=&r"(*b), "=c"(*c), "=d"(*d)
+                     : "0"(leaf), "2"(subleaf));
+#else
+    __asm__ volatile("cpuid"
+                     : "=a"(*a), "=b"(*b), "=c"(*c), "=d"(*d)
+                     : "0"(leaf), "2"(subleaf));
+#endif
+}
+
+static unsigned detect_cache_line_size_x86(void)
+{
+    unsigned a, b, c, d;
+    cpuid(1, 0, &a, &b, &c, &d);
+    unsigned size = ((b >> 8) & 0xff) * 8;
+    if (size == 0) {
+        cpuid(0x80000006, 0, &a, &b, &c, &d);
+        size = c & 0xff;
+    }
+    return size;
+}
+#endif
+
+#if defined(__aarch64__)
+static unsigned detect_cache_line_size_aarch64(void)
+{
+    unsigned long ctr;
+    __asm__ volatile("mrs %0, ctr_el0" : "=r"(ctr));
+    unsigned dminline = (ctr >> 16) & 0xf;
+    return 4u << dminline;
+}
+#endif
+
+static unsigned detect_cache_line_size(void)
+{
+#if defined(__x86_64__) || defined(__i386__)
+    unsigned size = detect_cache_line_size_x86();
+    return size ? size : SPINLOCK_CACHE_LINE_SIZE;
+#elif defined(__aarch64__)
+    unsigned size = detect_cache_line_size_aarch64();
+    return size ? size : SPINLOCK_CACHE_LINE_SIZE;
+#else
+    return SPINLOCK_CACHE_LINE_SIZE;
+#endif
+}
+
+unsigned spinlock_runtime_cache_line_size(void)
+{
+    if (detected_cache_line_size == 0)
+        detected_cache_line_size = detect_cache_line_size();
+    return detected_cache_line_size;
+}


### PR DESCRIPTION
## Summary
- add runtime cache line size detection and fallbacks
- expose runtime cache line size through header

## Testing
- `make test` *(fails: unrecognized command-line option '-std=c23')*