### PR TITLE
Remove generated metrics log

### DIFF
--- a/metrics_results.log
+++ b/metrics_results.log
@@ -1,1 +1,0 @@
-Total source lines: 2112194


### PR DESCRIPTION
## Summary
- remove `metrics_results.log` from version control
- ensure `.gitignore` keeps metrics log ignored

## Testing
- `git status --short`