### PR TITLE
Add process mailboxes and update build files

### DIFF
--- a/v10/ipc/h/mailbox.h
+++ b/v10/ipc/h/mailbox.h
@@ -1,0 +1,26 @@
+#ifndef MAILBOX_H
+#define MAILBOX_H
+
+#include <stddef.h>
+#include "spinlock.h"
+
+typedef struct message {
+    struct message *next;
+    size_t len;
+    char *data;
+} message_t;
+
+typedef struct mailbox {
+    spinlock_t lock;
+    message_t *head;
+    message_t *tail;
+} mailbox_t;
+
+void mailbox_init(mailbox_t *mb);
+int mailbox_send(mailbox_t *mb, const void *buf, size_t len);
+int mailbox_recv(mailbox_t *mb, void *buf, size_t *len);
+
+int exo_send(mailbox_t *target, const void *buf, size_t len);
+int exo_recv(mailbox_t *mb, void *buf, size_t *len);
+
+#endif /* MAILBOX_H */

--- a/v10/ipc/libipc/mailbox.c
+++ b/v10/ipc/libipc/mailbox.c
@@ -1,0 +1,72 @@
+#include <stdlib.h>
+#include <string.h>
+#include "../h/mailbox.h"
+
+void mailbox_init(mailbox_t *mb)
+{
+    mb->lock = (spinlock_t)SPINLOCK_INITIALIZER;
+    mb->head = mb->tail = NULL;
+}
+
+static message_t *message_alloc(const void *buf, size_t len)
+{
+    message_t *m = (message_t *)malloc(sizeof(message_t));
+    if(!m)
+        return NULL;
+    m->data = (char *)malloc(len);
+    if(!m->data) {
+        free(m);
+        return NULL;
+    }
+    memcpy(m->data, buf, len);
+    m->len = len;
+    m->next = NULL;
+    return m;
+}
+
+int mailbox_send(mailbox_t *mb, const void *buf, size_t len)
+{
+    message_t *m = message_alloc(buf, len);
+    if(!m)
+        return -1;
+    spin_lock(&mb->lock);
+    if(mb->tail)
+        mb->tail->next = m;
+    else
+        mb->head = m;
+    mb->tail = m;
+    spin_unlock(&mb->lock);
+    return 0;
+}
+
+int mailbox_recv(mailbox_t *mb, void *buf, size_t *len)
+{
+    spin_lock(&mb->lock);
+    message_t *m = mb->head;
+    if(!m) {
+        spin_unlock(&mb->lock);
+        return -1;
+    }
+    mb->head = m->next;
+    if(mb->tail == m)
+        mb->tail = NULL;
+    spin_unlock(&mb->lock);
+
+    if(buf && *len >= m->len)
+        memcpy(buf, m->data, m->len);
+    *len = m->len;
+    free(m->data);
+    free(m);
+    return 0;
+}
+
+int exo_send(mailbox_t *target, const void *buf, size_t len)
+{
+    return mailbox_send(target, buf, len);
+}
+
+int exo_recv(mailbox_t *mb, void *buf, size_t *len)
+{
+    return mailbox_recv(mb, buf, len);
+}
+

--- a/v10/ipc/libipc/mkfile
+++ b/v10/ipc/libipc/mkfile
@@ -2,9 +2,9 @@ INCS=-I. -I../h
 CFLAGS=-g $INCS
 L=libipc.a
 OBJS=$L(ipcopen.o) $L(ipccreat.o) $L(ipcproto.o) $L(pwsearch.o) $L(ipclogin.o)\
-    $L(ipcpath.o) $L(ipcexec.o) $L(ipcbuf.o) $L(qns.o) $L(spinlock.o)
+    $L(ipcpath.o) $L(ipcexec.o) $L(ipcbuf.o) $L(qns.o) $L(spinlock.o) $L(mailbox.o)
 COBJS=ipcopen.O ipccreat.O ipcproto.O pwsearch.O ipclogin.O ipcpath.O\
-    ipcexec.O ipcbuf.O qns.O spinlock.O
+    ipcexec.O ipcbuf.O qns.O spinlock.O mailbox.O
 NPROC=2
 
 all:V: cyntax $L

--- a/v10/sys/sys/proc.h
+++ b/v10/sys/sys/proc.h
@@ -5,7 +5,12 @@
  * process may be swapped out.
  * Other per process data (user.h)
  * is swapped with the process.
- */
+ *
+ * Each process now contains a mailbox used for
+ * inter-process communication.
+*/
+
+#include "../../ipc/h/mailbox.h"
 
 struct	proc
 {
@@ -52,6 +57,7 @@ struct	proc
 	short	Jp_idhash;	/* hashed based on p_pid for kill+exit+... */
 	struct	proc *p_pptr;	/* pointer to process structure of parent */
 	struct	inode *p_trace;	/* inode for tracing, see proca.c */
+	mailbox_t p_mailbox;    /* per-process mailbox */
 };
 
 #ifdef KERNEL


### PR DESCRIPTION
## Summary
- add mailbox structure and helper functions
- extend process struct with a mailbox
- build mailbox as part of libipc

## Testing
- `cc -std=c2x -pthread spinlock_test.c ../../v10/ipc/spinlock.c -I ../../v10/ipc/h -DSMP_ENABLED -o spinlock_test && ./spinlock_test > spinlock_output.txt && cat spinlock_output.txt`
- `cc -std=c2x -pthread thread_spinlock_stress.c ../../v10/ipc/spinlock.c -I ../../v10/ipc/h -DSMP_ENABLED -o thread_spinlock_stress && ./thread_spinlock_stress > thread_spinlock_output.txt && cat thread_spinlock_output.txt`
- `cc -std=c2x -pthread process_spinlock_stress.c ../../v10/ipc/spinlock.c -I ../../v10/ipc/h -DSMP_ENABLED -o process_spinlock_stress && ./process_spinlock_stress > process_spinlock_output.txt && cat process_spinlock_output.txt`
