### PR TITLE
Replace spl calls with spinlocks

### DIFF
--- a/v10/sys/ml/swtch.s
+++ b/v10/sys/ml/swtch.s
@@ -14,7 +14,7 @@
 /*
  * Setrq(p), using fancy VAX instructions.
  *
- * Call should be made at spl6(), and p->p_stat should be SRUN
+ * Requires the run queue lock and p->p_stat should be SRUN
  */
 	.globl	_Setrq		# <<<massaged to jsb by "asm.sed">>>
 _Setrq:
@@ -38,7 +38,7 @@ set3:	.asciz	"setrq"
 /*
  * Remrq(p), using fancy VAX instructions
  *
- * Call should be made at spl6().
+ * Requires the run queue lock.
  */
 	.globl	_Remrq		# <<<massaged to jsb by "asm.sed">>>
 _Remrq:


### PR DESCRIPTION
## Summary
- convert spl-based critical sections in `sys4.c` and `sig.c` to use `spinlock_t`
- add spinlock declarations
- adjust comments in `swtch.s` to mention run queue lock

## Testing
- `make check CFLAGS="-std=c2x"`