### PR TITLE
Standardize spinlock alignment

### DIFF
--- a/modern/tests/process_spinlock_stress.c
+++ b/modern/tests/process_spinlock_stress.c
@@ -9,7 +9,7 @@
 #define ITERATIONS 10000
 
 typedef struct {
-    spinlock_t lock;
+    SPINLOCK_ALIGNED spinlock_t lock;
     int counter;
 } shared_t;
 

--- a/modern/tests/spinlock_fairness.c
+++ b/modern/tests/spinlock_fairness.c
@@ -3,7 +3,7 @@
 #include <unistd.h>
 #include "../../v10/ipc/h/spinlock.h"
 
-static spinlock_t lock = SPINLOCK_INITIALIZER;
+static SPINLOCK_ALIGNED spinlock_t lock = SPINLOCK_INITIALIZER;
 static int order[2] = {-1, -1};
 static int index = 0;
 

--- a/modern/tests/spinlock_test.c
+++ b/modern/tests/spinlock_test.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include "../../v10/ipc/h/spinlock.h"
 
-static spinlock_t lock = SPINLOCK_INITIALIZER;
+static SPINLOCK_ALIGNED spinlock_t lock = SPINLOCK_INITIALIZER;
 static int counter = 0;
 
 void *worker(void *arg)

--- a/modern/tests/thread_spinlock_stress.c
+++ b/modern/tests/thread_spinlock_stress.c
@@ -5,7 +5,7 @@
 #define THREADS 4
 #define ITERATIONS 100000
 
-static spinlock_t lock = SPINLOCK_INITIALIZER;
+static SPINLOCK_ALIGNED spinlock_t lock = SPINLOCK_INITIALIZER;
 static int counter = 0;
 
 void *worker(void *arg)

--- a/v10/ipc/h/spinlock.h
+++ b/v10/ipc/h/spinlock.h
@@ -1,8 +1,10 @@
+#pragma once
 #ifndef SPINLOCK_H
 #define SPINLOCK_H
 
 #include <stdint.h>
 #include <stdatomic.h>
+#include <stdalign.h>
 
 #if defined(__GCC_DESTRUCTIVE_SIZE)
 #define SPINLOCK_CACHE_LINE_SIZE __GCC_DESTRUCTIVE_SIZE
@@ -25,16 +27,17 @@ static inline unsigned spinlock_cache_line_size(void)
 #define CACHE_LINE_SIZE SPINLOCK_CACHE_LINE_SIZE
 #endif
 
+#define SPINLOCK_ALIGNED alignas(CACHE_LINE_SIZE)
 #ifdef USE_TICKET_LOCK
 typedef struct {
     atomic_uint next;
     atomic_uint owner;
-} spinlock_t __attribute__((aligned(CACHE_LINE_SIZE)));
+} spinlock_t;
 #define SPINLOCK_INITIALIZER { ATOMIC_VAR_INIT(0), ATOMIC_VAR_INIT(0) }
 #else
 typedef struct {
     atomic_flag locked;
-} spinlock_t __attribute__((aligned(CACHE_LINE_SIZE)));
+} spinlock_t;
 #define SPINLOCK_INITIALIZER { ATOMIC_FLAG_INIT }
 #endif
 

--- a/v10/ipc/spinlock.c
+++ b/v10/ipc/spinlock.c
@@ -1,6 +1,6 @@
 #include "h/spinlock.h"
 
-spinlock_t ipc_lock = SPINLOCK_INITIALIZER;
+SPINLOCK_ALIGNED spinlock_t ipc_lock = SPINLOCK_INITIALIZER;
 
 #ifdef SMP_ENABLED
 #ifndef USE_TICKET_LOCK

--- a/v10/sys/inet/ip_input.c
+++ b/v10/sys/inet/ip_input.c
@@ -11,7 +11,7 @@ int	ipqmaxlen = 50;
 struct	ipq	ipq;			/* ip reass. queue */
 
 #ifdef SMP_ENABLED
-spinlock_t ipq_lock = SPINLOCK_INITIALIZER;
+SPINLOCK_ALIGNED spinlock_t ipq_lock = SPINLOCK_INITIALIZER;
 #endif
 u_char	ipcksum = 1;
 struct	block *ip_reass();

--- a/v10/sys/sys/buf.h
+++ b/v10/sys/sys/buf.h
@@ -70,7 +70,7 @@ struct	buf bswlist;		/* head of free swap header list */
 struct	buf *bclnlist;		/* head of cleaned page list */
 #ifdef SMP_ENABLED
 #include "../../ipc/h/spinlock.h"
-spinlock_t buf_lock = SPINLOCK_INITIALIZER;
+SPINLOCK_ALIGNED spinlock_t buf_lock = SPINLOCK_INITIALIZER;
 #endif
 
 struct	buf *alloc();


### PR DESCRIPTION
## Summary
- adopt `#pragma once` and `<stdalign.h>` in spinlock header
- define `SPINLOCK_ALIGNED` macro using `alignas`
- use `SPINLOCK_ALIGNED` for global and test spinlocks

## Testing
- `cc -std=c2x -I v10/ipc/h -I . /tmp/test.c v10/ipc/spinlock.c -o /tmp/test_c`
- `g++ -std=c++23 -I v10/ipc/h -I . /tmp/test.cpp v10/ipc/spinlock.c -o /tmp/test_cpp`
- `make -C modern/tests spinlock_test CFLAGS='-std=c2x -pthread -I ../../v10/ipc/h -DSMP_ENABLED'`
- `make -C modern/tests thread_spinlock_stress CFLAGS='-std=c2x -pthread -I ../../v10/ipc/h -DSMP_ENABLED'`
