### PR TITLE
Switch build to clang and modernize headers

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,3 @@
+set -e
+sudo apt-get update
+sudo apt-get install -y clang build-essential cmake make ninja-build

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ kernel:
 test: check
 
 check:
-	$(MAKE) -C modern/tests check
+	$(MAKE) -C modern/tests CC=$(CC) check
 
 clean:
 	$(MAKE) -C v10/sys clean

--- a/modern/tests/CMakeLists.txt
+++ b/modern/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ project(modern_tests C)
 set(CMAKE_C_STANDARD 23)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)
+add_compile_options(-Wall -Wextra -Werror)
 add_compile_definitions(_POSIX_C_SOURCE=200809L _GNU_SOURCE)
 
 find_package(Threads REQUIRED)

--- a/modern/tests/Makefile
+++ b/modern/tests/Makefile
@@ -1,7 +1,7 @@
 # Set CROSS_COMPILE using `source tools/cross-env.sh <arch>`
 CROSS_COMPILE ?=
-CC ?= $(CROSS_COMPILE)gcc
-CFLAGS = -std=c23 -pthread -I ../compat -I ../../v10/ipc/h -DSMP_ENABLED
+CC = $(CROSS_COMPILE)clang
+CFLAGS = -std=c23 -Wall -Wextra -Werror -pthread -I ../compat -I ../../v10/ipc/h -DSMP_ENABLED
 SPINLOCK_SRC = ../../v10/ipc/spinlock.c
 
 TESTS = c23_hello spinlock_test thread_spinlock_stress \

--- a/modern/tests/c23_test.sh
+++ b/modern/tests/c23_test.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Build and run the C23 demo program.
-CC=${CC:-cc}
+CC=${CC:-clang}
 set -e
-$CC -std=c2x c23_hello.c -o c23_hello
+$CC -std=c23 -Wall -Wextra -Werror c23_hello.c -o c23_hello
 ./c23_hello > output.txt
 if grep -q "Hello from C23" output.txt; then
     echo "C23 executable ran successfully"

--- a/modern/tests/process_spinlock_stress.sh
+++ b/modern/tests/process_spinlock_stress.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-cc -std=c23 -pthread process_spinlock_stress.c ../../v10/ipc/spinlock.c -I ../compat -I ../../v10/ipc/h -DSMP_ENABLED -o process_spinlock_stress
+clang -std=c23 -Wall -Wextra -Werror -pthread process_spinlock_stress.c ../../v10/ipc/spinlock.c -I ../compat -I ../../v10/ipc/h -DSMP_ENABLED -o process_spinlock_stress
 ./process_spinlock_stress > process_spinlock_output.txt
 if grep -q "counter=40000" process_spinlock_output.txt; then
     echo "process spinlock stress test passed"

--- a/modern/tests/ptrace_concurrency_test.sh
+++ b/modern/tests/ptrace_concurrency_test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-cc -std=c23 -pthread ptrace_concurrency_test.c -o ptrace_concurrency_test
+clang -std=c23 -Wall -Wextra -Werror -pthread ptrace_concurrency_test.c -o ptrace_concurrency_test
 ./ptrace_concurrency_test > ptrace_concurrency_output.txt
 if grep -q "ptrace concurrency test completed" ptrace_concurrency_output.txt; then
     echo "ptrace concurrency test passed"

--- a/modern/tests/spinlock_test.sh
+++ b/modern/tests/spinlock_test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-cc -std=c23 -pthread spinlock_test.c ../../v10/ipc/spinlock.c -I ../compat -I ../../v10/ipc/h -DSMP_ENABLED -o spinlock_test
+clang -std=c23 -Wall -Wextra -Werror -pthread spinlock_test.c ../../v10/ipc/spinlock.c -I ../compat -I ../../v10/ipc/h -DSMP_ENABLED -o spinlock_test
 ./spinlock_test > spinlock_output.txt
 if grep -q "counter=200000" spinlock_output.txt; then
     echo "spinlock test passed"

--- a/modern/tests/thread_spinlock_stress.sh
+++ b/modern/tests/thread_spinlock_stress.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-cc -std=c23 -pthread thread_spinlock_stress.c ../../v10/ipc/spinlock.c -I ../compat -I ../../v10/ipc/h -DSMP_ENABLED -o thread_spinlock_stress
+clang -std=c23 -Wall -Wextra -Werror -pthread thread_spinlock_stress.c ../../v10/ipc/spinlock.c -I ../compat -I ../../v10/ipc/h -DSMP_ENABLED -o thread_spinlock_stress
 ./thread_spinlock_stress > thread_spinlock_output.txt
 if grep -q "counter=400000" thread_spinlock_output.txt; then
     echo "thread spinlock stress test passed"

--- a/r70/CC/sys/types.h
+++ b/r70/CC/sys/types.h
@@ -1,5 +1,6 @@
 #ifndef __SYS_TYPES
 #define __SYS_TYPES
+#include <stdint.h>
 
 /*
  * Basic system types and related macros
@@ -29,10 +30,6 @@
 /* bytes to clicks */
 #define	btoc(x)	((((unsigned)(x)+511)>>9))
 
-typedef	unsigned char	u_char;
-typedef	unsigned short	u_short;
-typedef	unsigned int	u_int;
-typedef	unsigned long	u_long;
 
 typedef	long	daddr_t;
 typedef	char *	caddr_t;

--- a/r70/CC/types.h
+++ b/r70/CC/types.h
@@ -4,6 +4,7 @@
 
 #ifndef _TYPES_
 #define	_TYPES_
+#include <stdint.h>
 
 /* major part of a device */
 #define	major(x)	((int)(((unsigned)(x)>>8)&0377))
@@ -14,10 +15,6 @@
 /* make a device number */
 #define	makedev(x,y)	((dev_t)(((x)<<8) | (y)))
 
-typedef	unsigned char	u_char;
-typedef	unsigned short	u_short;
-typedef	unsigned int	u_int;
-typedef	unsigned long	u_long;
 
 typedef	struct	_physadr { int r[1]; } *physadr;
 typedef	long	daddr_t;

--- a/r70/oCC/sys/types.h
+++ b/r70/oCC/sys/types.h
@@ -4,6 +4,7 @@
 
 #ifndef _TYPES_
 #define	_TYPES_
+#include <stdint.h>
 
 /* major part of a device */
 #define	major(x)	((int)(((unsigned)(x)>>8)&0377))
@@ -14,10 +15,6 @@
 /* make a device number */
 #define	makedev(x,y)	((dev_t)(((x)<<8) | (y)))
 
-typedef	unsigned char	u_char;
-typedef	unsigned short	u_short;
-typedef	unsigned int	u_int;
-typedef	unsigned long	u_long;
 
 typedef	struct	_physadr { int r[1]; } *physadr;
 typedef	long	daddr_t;

--- a/r70/sys/types.h
+++ b/r70/sys/types.h
@@ -6,6 +6,7 @@
 /*
  * hardware parameters
  */
+#include <stdint.h>
 
 #define	NBBY		8		/* number of bits in a byte */
 #define	NBPW		sizeof(int)	/* number of bytes in an integer */
@@ -30,10 +31,6 @@
  * these should go away;
  * just say `unsigned'
  */
-typedef	unsigned char	u_char;
-typedef	unsigned short	u_short;
-typedef	unsigned int	u_int;
-typedef	unsigned long	u_long;
 
 typedef	long	daddr_t;	/* disk blocks */
 typedef	char *	caddr_t;

--- a/v10/sys/Makefile
+++ b/v10/sys/Makefile
@@ -1,6 +1,6 @@
 ARCH ?= $(shell uname -m)
 CROSS_COMPILE ?=
-CC ?= $(CROSS_COMPILE)gcc
+CC = $(CROSS_COMPILE)clang
 CFLAGS ?= -O
 LDFLAGS ?=
 SMP ?= 0

--- a/v10/sys/sys/types.h
+++ b/v10/sys/sys/types.h
@@ -7,6 +7,7 @@
  * hardware parameters
  */
 
+#include <stdint.h>
 #define	NBBY		8		/* number of bits in a byte */
 #define	NBPW		sizeof(int)	/* number of bytes in an integer */
 #define	NBPG		512		/* bytes per hardware page */
@@ -30,10 +31,6 @@
  * these should go away;
  * just say `unsigned'
  */
-typedef	unsigned char	u_char;
-typedef	unsigned short	u_short;
-typedef	unsigned int	u_int;
-typedef	unsigned long	u_long;
 
 typedef	long	daddr_t;	/* disk blocks */
 typedef	char *	caddr_t;


### PR DESCRIPTION
## Summary
- add setup script installing clang via apt
- build tests with clang and treat warnings as errors
- default kernel build to clang
- remove BSD integer typedefs from `sys/types.h`
- include `<stdint.h>` in architecture-specific headers

## Testing
- `make check CC=clang` *(fails: unknown type errors in spinlock_test.c)*