### PR TITLE
Update spinlock for uniprocessor mode

### DIFF
--- a/v10/ipc/h/spinlock.h
+++ b/v10/ipc/h/spinlock.h
@@ -43,7 +43,10 @@ typedef struct {
 #define SPINLOCK_INITIALIZER { ATOMIC_FLAG_INIT }
 #endif
 
-#ifdef SMP_ENABLED
+#ifdef SPINLOCK_UNIPROCESSOR
+#define spin_lock(l) ((void)0)
+#define spin_unlock(l) ((void)0)
+#elif defined(SMP_ENABLED)
 void spin_lock(spinlock_t *lock);
 void spin_unlock(spinlock_t *lock);
 #else

--- a/v10/ipc/spinlock.c
+++ b/v10/ipc/spinlock.c
@@ -2,7 +2,7 @@
 
 SPINLOCK_ALIGNED spinlock_t ipc_lock = SPINLOCK_INITIALIZER;
 
-#ifdef SMP_ENABLED
+#if defined(SMP_ENABLED) && !defined(SPINLOCK_UNIPROCESSOR)
 #ifndef USE_TICKET_LOCK
 void spin_lock(spinlock_t *lock)
 {


### PR DESCRIPTION
## Summary
- allow `SPINLOCK_UNIPROCESSOR` to disable locking even if `SMP_ENABLED` is set
- prevent spinlock function definitions when uniprocessor mode is active

## Testing
- `clang -c ../v10/ipc/spinlock.c -I../v10/ipc/h -DSPINLOCK_UNIPROCESSOR`
- `clang -c ../v10/ipc/spinlock.c -I../v10/ipc/h -DSMP_ENABLED`
- `clang -c ../v10/ipc/spinlock.c -I../v10/ipc/h -DSPINLOCK_UNIPROCESSOR -DSMP_ENABLED`