### PR TITLE
Introduce ipc_status enum for mailbox IPC

### DIFF
--- a/docs/IPC.md
+++ b/docs/IPC.md
@@ -19,6 +19,13 @@ value expressed in system ticks.  Internally they use the kernel's
 timeout expires, the operation returns with an error code and no
 message is transferred.
 
+### Status codes
+Mailbox operations return an `ipc_status` value:
+
+- `IPC_STATUS_SUCCESS` – operation completed successfully.
+- `IPC_STATUS_TIMEOUT` – the timeout expired before completion.
+- `IPC_STATUS_ERROR` – a generic failure occurred.
+
 ## Example usage
 The snippet below sends a message and waits up to one second (100 ticks)
 for a reply:
@@ -29,9 +36,9 @@ struct mbox *resp = mbox_open("resp");
 struct msg m = { .cmd = PING };
 
 mbox_send(req, &m, 0);           /* block until sent */
-if (mbox_recv(resp, &m, 100) == 0) {
+if (mbox_recv(resp, &m, 100) == IPC_STATUS_SUCCESS) {
     /* process reply */
 } else {
-    /* timeout */
+    /* timeout or error */
 }
 ```

--- a/v10/ipc/h/ipc.h
+++ b/v10/ipc/h/ipc.h
@@ -33,6 +33,13 @@ extern int ipcrogin();
 extern char *ipcpath();
 extern int ipcexec();
 
+/* status codes for mailbox style IPC */
+typedef enum {
+    IPC_STATUS_SUCCESS = 0,
+    IPC_STATUS_TIMEOUT,
+    IPC_STATUS_ERROR
+} ipc_status;
+
 /* import */
 extern int errno;
 extern char *errstr;

--- a/v10/ipc/h/mailbox.h
+++ b/v10/ipc/h/mailbox.h
@@ -3,6 +3,7 @@
 
 #include <stddef.h>
 #include "spinlock.h"
+#include "ipc.h"
 
 typedef struct message {
     struct message *next;
@@ -17,10 +18,10 @@ typedef struct mailbox {
 } mailbox_t;
 
 void mailbox_init(mailbox_t *mb);
-int mailbox_send(mailbox_t *mb, const void *buf, size_t len);
-int mailbox_recv(mailbox_t *mb, void *buf, size_t *len);
+ipc_status mailbox_send(mailbox_t *mb, const void *buf, size_t len);
+ipc_status mailbox_recv(mailbox_t *mb, void *buf, size_t *len);
 
-int exo_send(mailbox_t *target, const void *buf, size_t len);
-int exo_recv(mailbox_t *mb, void *buf, size_t *len);
+ipc_status exo_send(mailbox_t *target, const void *buf, size_t len);
+ipc_status exo_recv(mailbox_t *mb, void *buf, size_t *len);
 
 #endif /* MAILBOX_H */


### PR DESCRIPTION
## Summary
- add `ipc_status` enum in ipc.h
- update mailbox API to return the enum
- reference new enum in docs and example code

## Testing
- `make check` *(fails: unrecognized command line option `-std=c23`)*