### PR TITLE
Add ipc_mailbox helper functions

### DIFF
--- a/docs/microkernel.md
+++ b/docs/microkernel.md
@@ -1,0 +1,15 @@
+# Microkernel Overview
+
+This document collects notes about the simple microkernel used by the
+modernized Research UNIX environment.
+
+## Mailbox Usage
+
+Every process is associated with an `ipc_mailbox` managed by the `libipc`
+library.  The mailboxes reside in the global array `proc_mailboxes` indexed by
+process ID.  Use `ipc_get_mailbox(pid)` to obtain another process's mailbox or
+`ipc_current_mailbox()` for the current process.
+
+Messages are queued with `mailbox_send()` and retrieved with
+`mailbox_recv()`.  These helpers automatically initialise the per-process
+mailboxes on first use.

--- a/v10/ipc/h/mailbox.h
+++ b/v10/ipc/h/mailbox.h
@@ -2,6 +2,7 @@
 #define MAILBOX_H
 
 #include <stddef.h>
+#include <sys/types.h>
 #include "spinlock.h"
 
 typedef struct message {
@@ -16,9 +17,18 @@ typedef struct mailbox {
     message_t *tail;
 } mailbox_t;
 
+/* per-process mailbox wrapper */
+typedef struct ipc_mailbox {
+    mailbox_t box;
+    /* additional metadata */
+} ipc_mailbox;
+
 void mailbox_init(mailbox_t *mb);
 int mailbox_send(mailbox_t *mb, const void *buf, size_t len);
 int mailbox_recv(mailbox_t *mb, void *buf, size_t *len);
+
+ipc_mailbox *ipc_get_mailbox(pid_t pid);
+ipc_mailbox *ipc_current_mailbox(void);
 
 int exo_send(mailbox_t *target, const void *buf, size_t len);
 int exo_recv(mailbox_t *mb, void *buf, size_t *len);

--- a/v10/ipc/libipc/mailbox.c
+++ b/v10/ipc/libipc/mailbox.c
@@ -1,6 +1,41 @@
 #include <stdlib.h>
 #include <string.h>
 #include "../h/mailbox.h"
+#include <sys/types.h>
+#include <unistd.h>
+
+/*
+ * per-process mailboxes
+ */
+ipc_mailbox proc_mailboxes[NPROC];
+static int mb_initialized;
+
+static void
+init_proc_mailboxes(void)
+{
+    int i;
+
+    if(mb_initialized)
+        return;
+    for(i=0; i<NPROC; i++)
+        mailbox_init(&proc_mailboxes[i].box);
+    mb_initialized = 1;
+}
+
+ipc_mailbox *
+ipc_get_mailbox(pid_t pid)
+{
+    if(pid < 0 || pid >= NPROC)
+        return NULL;
+    init_proc_mailboxes();
+    return &proc_mailboxes[pid];
+}
+
+ipc_mailbox *
+ipc_current_mailbox(void)
+{
+    return ipc_get_mailbox(getpid());
+}
 
 void mailbox_init(mailbox_t *mb)
 {


### PR DESCRIPTION
## Summary
- define `ipc_mailbox` in mailbox.h
- implement per-process mailbox lookup helpers in libipc
- document mailbox usage in new microkernel docs

## Testing
- `make check` *(fails: unrecognized option `-std=c23`)*