### PR TITLE
Add spinlock guarding scheduler queues

### DIFF
--- a/v10/sys/CMakeLists.txt
+++ b/v10/sys/CMakeLists.txt
@@ -33,6 +33,10 @@ file(GLOB SRC_C
     "inet/*.c"
 )
 
+# ensure scheduler lock support is built
+list(APPEND SRC_C os/sched_lock.c)
+list(REMOVE_DUPLICATES SRC_C)
+
 file(GLOB SRC_S
     "os/*.s"
     "vm/*.s"

--- a/v10/sys/os/Makefile
+++ b/v10/sys/os/Makefile
@@ -4,6 +4,8 @@ CFLAGS ?= -O
 CFLAGS += -std=c23 -I ..
 
 SRC_C := $(wildcard *.c)
+# ensure scheduler lock support is built
+SRC_C += sched_lock.c
 SRC_S := $(wildcard *.s)
 OBJ := $(SRC_C:.c=.o) $(SRC_S:.s=.o)
 

--- a/v10/sys/os/sched_lock.c
+++ b/v10/sys/os/sched_lock.c
@@ -1,0 +1,21 @@
+#include "sys/sched.h"
+
+#ifdef SPINLOCK_UNIPROCESSOR
+
+void sched_lock_acquire(void) {}
+void sched_lock_release(void) {}
+
+#else
+SPINLOCK_ALIGNED spinlock_t sched_lock = SPINLOCK_INITIALIZER;
+
+void sched_lock_acquire(void)
+{
+    spin_lock(&sched_lock);
+}
+
+void sched_lock_release(void)
+{
+    spin_unlock(&sched_lock);
+}
+#endif
+

--- a/v10/sys/sys/sched.h
+++ b/v10/sys/sys/sched.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "../../ipc/h/spinlock.h"
+
+#ifdef SMP_ENABLED
+extern spinlock_t sched_lock;
+#endif
+
+void sched_lock_acquire(void);
+void sched_lock_release(void);
+


### PR DESCRIPTION
## Summary
- introduce `sched_lock` and helpers
- compile scheduler lock for the OS build systems
- guard run queue operations in assembly with scheduler lock

## Testing
- `make` *(fails: unknown type name 'u_short')*