### PR TITLE
Update test toolchain defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 
 ARCH ?= $(shell uname -m)
 CROSS_COMPILE ?=
+# Default to clang for building test utilities
+CC ?= clang
 
 all: kernel test
 
@@ -9,6 +11,14 @@ kernel:
 	$(MAKE) -C v10/sys ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE)
 
 test: check
+ifeq ($(CAPNP),1)
+       $(MAKE) -C modern/tests CC=$(CC) mailbox_timeout_test
+       $(MAKE) -C modern/memory_server CC=$(CC) all
+       ./modern/memory_server/memory_server & \
+       memsrv_pid=$$!; \
+       ./modern/tests/mailbox_timeout_test; \
+       kill $$memsrv_pid
+endif
 
 check:
 	$(MAKE) -C modern/tests CC=$(CC) check

--- a/modern/tests/process_spinlock_stress.sh
+++ b/modern/tests/process_spinlock_stress.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -e
-clang -std=c23 -Wall -Wextra -Werror -pthread process_spinlock_stress.c ../../v10/ipc/spinlock.c -I ../compat -I ../../v10/ipc/h -DSMP_ENABLED -o process_spinlock_stress
+CC=${CC:-clang}
+$CC -std=c23 -Wall -Wextra -Werror -pthread process_spinlock_stress.c ../../v10/ipc/spinlock.c -I ../compat -I ../../v10/ipc/h -DSMP_ENABLED -o process_spinlock_stress
 ./process_spinlock_stress > process_spinlock_output.txt
 if grep -q "counter=40000" process_spinlock_output.txt; then
     echo "process spinlock stress test passed"

--- a/modern/tests/ptrace_concurrency_test.sh
+++ b/modern/tests/ptrace_concurrency_test.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -e
-clang -std=c23 -Wall -Wextra -Werror -pthread ptrace_concurrency_test.c -o ptrace_concurrency_test
+CC=${CC:-clang}
+$CC -std=c23 -Wall -Wextra -Werror -pthread ptrace_concurrency_test.c -o ptrace_concurrency_test
 ./ptrace_concurrency_test > ptrace_concurrency_output.txt
 if grep -q "ptrace concurrency test completed" ptrace_concurrency_output.txt; then
     echo "ptrace concurrency test passed"

--- a/modern/tests/spinlock_test.sh
+++ b/modern/tests/spinlock_test.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -e
-clang -std=c23 -Wall -Wextra -Werror -pthread spinlock_test.c ../../v10/ipc/spinlock.c -I ../compat -I ../../v10/ipc/h -DSMP_ENABLED -o spinlock_test
+CC=${CC:-clang}
+$CC -std=c23 -Wall -Wextra -Werror -pthread spinlock_test.c ../../v10/ipc/spinlock.c -I ../compat -I ../../v10/ipc/h -DSMP_ENABLED -o spinlock_test
 ./spinlock_test > spinlock_output.txt
 if grep -q "counter=200000" spinlock_output.txt; then
     echo "spinlock test passed"

--- a/modern/tests/thread_spinlock_stress.sh
+++ b/modern/tests/thread_spinlock_stress.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -e
-clang -std=c23 -Wall -Wextra -Werror -pthread thread_spinlock_stress.c ../../v10/ipc/spinlock.c -I ../compat -I ../../v10/ipc/h -DSMP_ENABLED -o thread_spinlock_stress
+CC=${CC:-clang}
+$CC -std=c23 -Wall -Wextra -Werror -pthread thread_spinlock_stress.c ../../v10/ipc/spinlock.c -I ../compat -I ../../v10/ipc/h -DSMP_ENABLED -o thread_spinlock_stress
 ./thread_spinlock_stress > thread_spinlock_output.txt
 if grep -q "counter=400000" thread_spinlock_output.txt; then
     echo "thread spinlock stress test passed"


### PR DESCRIPTION
## Summary
- default to clang in the root Makefile
- run mailbox timeout tests and memory server when CAPNP=1
- use `$CC` with C23 in test scripts

## Testing
- `sh tools/metrics.sh`
- `make test` *(fails: cc doesn't recognize `-std=c23`)*