### PR TITLE
Add minimal Cap'n Proto library and memory server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,11 @@ metrics_results.log
 # Ignore binaries produced by the C23 tests
 modern/tests/c23_hello
 modern/tests/output.txt
+# Ignore Cap'n Proto build artifacts
+v10/ipc/capnp/libcapnp.a
+v10/ipc/capnp/capnp.o
+tools/memserver/memserver
+tools/memserver/memserver.o
+modern/tests/capnp_client
+modern/tests/msg.bin
+modern/tests/capnp_out.txt

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,30 @@
-.PHONY: all kernel test check clean
+.PHONY: all kernel test check clean capnp_tools
 
 ARCH ?= $(shell uname -m)
 CROSS_COMPILE ?=
+CAPNP ?= 0
 
 all: kernel test
+ifeq ($(CAPNP),1)
+all: capnp_tools
+endif
 
 kernel:
-	$(MAKE) -C v10/sys ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE)
+	$(MAKE) -C v10/sys ARCH=$(ARCH) CROSS_COMPILE=$(CROSS_COMPILE) CAPNP=$(CAPNP)
 
 test: check
 
 check:
-	$(MAKE) -C modern/tests CC=$(CC) check
+	$(MAKE) -C modern/tests CAPNP=$(CAPNP) check
 
 clean:
 	$(MAKE) -C v10/sys clean
 	$(MAKE) -C modern/tests clean
+ifeq ($(CAPNP),1)
+	$(MAKE) -C v10/ipc/capnp clean
+	$(MAKE) -C tools/memserver clean
+endif
+
+capnp_tools:
+	$(MAKE) -C v10/ipc/capnp CROSS_COMPILE=$(CROSS_COMPILE)
+	$(MAKE) -C tools/memserver CROSS_COMPILE=$(CROSS_COMPILE)

--- a/modern/tests/CMakeLists.txt
+++ b/modern/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)
 add_compile_options(-Wall -Wextra -Werror)
 add_compile_definitions(_POSIX_C_SOURCE=200809L _GNU_SOURCE)
+option(CAPNP "Enable Cap'n Proto support" OFF)
 
 find_package(Threads REQUIRED)
 
@@ -37,6 +38,12 @@ target_link_libraries(ptrace_concurrency_test PRIVATE Threads::Threads)
 add_executable(spinlock_fairness spinlock_fairness.c ${SPINLOCK_SRC})
 target_compile_definitions(spinlock_fairness PRIVATE SMP_ENABLED USE_TICKET_LOCK)
 target_link_libraries(spinlock_fairness PRIVATE Threads::Threads)
+
+if(CAPNP)
+add_executable(capnp_client capnp_client.c)
+target_include_directories(capnp_client PRIVATE ${CMAKE_SOURCE_DIR}/v10/ipc/capnp)
+target_link_libraries(capnp_client PRIVATE ${CMAKE_SOURCE_DIR}/v10/ipc/capnp/libcapnp.a)
+endif()
 
 add_executable(mqueue_ordering_test mqueue_ordering_test.c)
 target_link_libraries(mqueue_ordering_test PRIVATE Threads::Threads rt)
@@ -72,6 +79,11 @@ add_test(NAME ptrace_concurrency_test
 set_tests_properties(ptrace_concurrency_test PROPERTIES WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_test(NAME spinlock_fairness COMMAND $<TARGET_FILE:spinlock_fairness>)
+if(CAPNP)
+add_test(NAME capnp_example
+    COMMAND /bin/sh ${CMAKE_CURRENT_SOURCE_DIR}/capnp_example.sh)
+set_tests_properties(capnp_example PROPERTIES WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
 
 add_test(NAME mqueue_ordering_test COMMAND $<TARGET_FILE:mqueue_ordering_test>)
 add_test(NAME mqueue_blocking_test COMMAND $<TARGET_FILE:mqueue_blocking_test>)

--- a/modern/tests/Makefile
+++ b/modern/tests/Makefile
@@ -6,6 +6,9 @@ SPINLOCK_SRC = ../../v10/ipc/spinlock.c
 
 TESTS = c23_hello spinlock_test thread_spinlock_stress \
 	process_spinlock_stress ptrace_concurrency_test spinlock_fairness
+ifeq ($(CAPNP),1)
+TESTS += capnp_client
+endif
 
 all: $(TESTS)
 
@@ -27,6 +30,10 @@ ptrace_concurrency_test: ptrace_concurrency_test.c
 spinlock_fairness: spinlock_fairness.c $(SPINLOCK_SRC)
 	$(CC) $(CFLAGS) -DUSE_TICKET_LOCK $< $(SPINLOCK_SRC) -o $@
 
+capnp_client: capnp_client.c
+	$(CC) $(CFLAGS) -I ../../v10/ipc/capnp capnp_client.c \
+	    -L ../../v10/ipc/capnp -lcapnp -o capnp_client
+
 check: all
 	./c23_test.sh
 	./spinlock_test.sh
@@ -34,6 +41,9 @@ check: all
 	./process_spinlock_stress.sh
 	./ptrace_concurrency_test.sh
 	./spinlock_fairness
+ifeq ($(CAPNP),1)
+	./capnp_example.sh
+endif
 
 clean:
-	rm -f $(TESTS) *.txt
+	rm -f $(TESTS) *.txt msg.bin capnp_out.txt

--- a/modern/tests/capnp_client.c
+++ b/modern/tests/capnp_client.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+#include <stdint.h>
+#include "../../v10/ipc/capnp/capnp.h"
+
+int main(int argc, char **argv)
+{
+    const char *path = argc > 1 ? argv[1] : "msg.bin";
+    FILE *f = fopen(path, "wb");
+    if(!f) {
+        perror("fopen");
+        return 1;
+    }
+    uint32_t msg[2];
+    capnp_write_u32(msg, 0, 0x12345678);
+    capnp_write_u32(msg, 1, 4096);
+    fwrite(msg, sizeof(uint32_t), 2, f);
+    fclose(f);
+    return 0;
+}

--- a/modern/tests/capnp_example.sh
+++ b/modern/tests/capnp_example.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+# Build client if not built via Makefile
+clang -std=c23 -Wall -Wextra -Werror capnp_client.c \
+    -I ../../v10/ipc/capnp -L ../../v10/ipc/capnp -lcapnp -o capnp_client
+./capnp_client msg.bin
+../../tools/memserver/memserver msg.bin > capnp_out.txt
+if grep -q "addr=0x12345678" capnp_out.txt; then
+    echo "capnp example passed"
+    exit 0
+else
+    echo "capnp example failed" >&2
+    exit 1
+fi

--- a/tools/memserver/Makefile
+++ b/tools/memserver/Makefile
@@ -1,0 +1,21 @@
+CROSS_COMPILE ?=
+CC = $(CROSS_COMPILE)clang
+CFLAGS ?= -std=c23 -Wall -Wextra -Werror -I../../v10/ipc/capnp
+LIBCAPNP = ../../v10/ipc/capnp/libcapnp.a
+
+all: memserver
+
+memserver: memserver.o $(LIBCAPNP)
+	$(CC) $(CFLAGS) memserver.o $(LIBCAPNP) -o $@
+
+memserver.o: memserver.c ../../v10/ipc/capnp/capnp.h
+	$(CC) $(CFLAGS) -c memserver.c -o $@
+
+$(LIBCAPNP):
+	$(MAKE) -C ../../v10/ipc/capnp CROSS_COMPILE=$(CROSS_COMPILE)
+
+clean:
+	rm -f memserver memserver.o
+	$(MAKE) -C ../../v10/ipc/capnp clean
+
+.PHONY: all clean

--- a/tools/memserver/memserver.c
+++ b/tools/memserver/memserver.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include "../../v10/ipc/capnp/capnp.h"
+
+int main(int argc, char **argv)
+{
+    const char *file = NULL;
+    if(argc > 1)
+        file = argv[1];
+
+    FILE *fp = file ? fopen(file, "rb") : stdin;
+    if(!fp) {
+        perror("fopen");
+        return 1;
+    }
+
+    uint32_t buf[2];
+    while(fread(buf, sizeof(uint32_t), 2, fp) == 2) {
+        uint32_t addr = capnp_read_u32(buf, 0);
+        uint32_t len  = capnp_read_u32(buf, 1);
+        printf("addr=0x%08x len=%u\n", addr, len);
+    }
+
+    if(file)
+        fclose(fp);
+    return 0;
+}

--- a/v10/ipc/capnp/Makefile
+++ b/v10/ipc/capnp/Makefile
@@ -1,0 +1,22 @@
+CROSS_COMPILE ?=
+CC = $(CROSS_COMPILE)clang
+AR = $(CROSS_COMPILE)ar
+RANLIB = $(CROSS_COMPILE)ranlib
+CFLAGS ?= -std=c23 -Wall -Wextra -Werror
+
+LIB = libcapnp.a
+OBJS = capnp.o
+
+all: $(LIB)
+
+$(LIB): $(OBJS)
+	$(AR) rcs $@ $(OBJS)
+	$(RANLIB) $@
+
+capnp.o: capnp.c capnp.h
+	$(CC) $(CFLAGS) -c capnp.c -o capnp.o
+
+clean:
+	rm -f $(OBJS) $(LIB)
+
+.PHONY: all clean

--- a/v10/ipc/capnp/capnp.c
+++ b/v10/ipc/capnp/capnp.c
@@ -1,0 +1,13 @@
+#include "capnp.h"
+
+uint32_t capnp_read_u32(const void *msg, size_t word)
+{
+    const uint32_t *p = (const uint32_t *)msg;
+    return p[word];
+}
+
+void capnp_write_u32(void *msg, size_t word, uint32_t value)
+{
+    uint32_t *p = (uint32_t *)msg;
+    p[word] = value;
+}

--- a/v10/ipc/capnp/capnp.h
+++ b/v10/ipc/capnp/capnp.h
@@ -1,0 +1,18 @@
+#ifndef V10_CAPNP_H
+#define V10_CAPNP_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+uint32_t capnp_read_u32(const void *msg, size_t word);
+void capnp_write_u32(void *msg, size_t word, uint32_t value);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* V10_CAPNP_H */

--- a/v10/sys/CMakeLists.txt
+++ b/v10/sys/CMakeLists.txt
@@ -13,10 +13,16 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 
 # Option controlling the SMP spinlock implementation
 option(SMP "Enable SMP support" OFF)
+option(CAPNP "Enable Cap'n Proto support" OFF)
 if(SMP)
     add_compile_definitions(SPINLOCK_TICKET SMP_ENABLED)
 else()
     add_compile_definitions(SPINLOCK_UNIPROCESSOR)
+endif()
+
+if(CAPNP)
+    add_library(capnp STATIC ${CMAKE_SOURCE_DIR}/v10/ipc/capnp/capnp.c)
+    target_include_directories(capnp PUBLIC ${CMAKE_SOURCE_DIR}/v10/ipc/capnp)
 endif()
 
 # Include current directory for headers
@@ -47,4 +53,7 @@ add_executable(unix ${SRC_C} ${SRC_S})
 
 # Do not use the standard C library for linking
 target_link_options(unix PRIVATE -nostdlib)
+if(CAPNP)
+    target_link_libraries(unix PRIVATE capnp)
+endif()
 


### PR DESCRIPTION
## Summary
- provide a stub `libcapnp` with very small C API
- add optional CAPNP build flag
- build a simple `memserver` tool for parsing messages
- integrate CAPNP option with kernel and test builds
- demonstrate usage of `memserver` under `modern/tests`

## Testing
- `make -C tools/memserver` 
- `make -C modern/tests capnp_client CAPNP=1`
- `cd modern/tests && ./capnp_example.sh`