### PR TITLE
Add timed mailbox receive API and regression tests

### DIFF
--- a/docs/IPC.md
+++ b/docs/IPC.md
@@ -35,3 +35,13 @@ if (mbox_recv(resp, &m, 100) == 0) {
     /* timeout */
 }
 ```
+
+User programs may include `<mailbox_t.h>` and call the `Recv_T` helper,
+which simply forwards to `mailbox_recv_t` with the given timeout:
+
+```c
+size_t len = sizeof(m);
+if (Recv_T(resp, &m, &len, 50) == 0) {
+    /* got a message within 50 ticks */
+}
+```

--- a/modern/compat/spinlock.h
+++ b/modern/compat/spinlock.h
@@ -5,6 +5,10 @@
 #include <stdatomic.h>
 #include <stdalign.h>
 
+#ifndef ATOMIC_VAR_INIT
+#define ATOMIC_VAR_INIT(value) (value)
+#endif
+
 #if defined(__GCC_DESTRUCTIVE_SIZE)
 #define SPINLOCK_CACHE_LINE_SIZE __GCC_DESTRUCTIVE_SIZE
 #elif defined(__x86_64__) || defined(__i386__)
@@ -26,16 +30,17 @@ static inline unsigned spinlock_cache_line_size(void)
 #define CACHE_LINE_SIZE SPINLOCK_CACHE_LINE_SIZE
 #endif
 
+#define SPINLOCK_ALIGNED alignas(CACHE_LINE_SIZE)
 #ifdef USE_TICKET_LOCK
 typedef struct {
     atomic_uint next;
     atomic_uint owner;
-} alignas(CACHE_LINE_SIZE) spinlock_t;
+} spinlock_t;
 #define SPINLOCK_INITIALIZER { ATOMIC_VAR_INIT(0), ATOMIC_VAR_INIT(0) }
 #else
 typedef struct {
     atomic_flag locked;
-} alignas(CACHE_LINE_SIZE) spinlock_t;
+} spinlock_t;
 #define SPINLOCK_INITIALIZER { ATOMIC_FLAG_INIT }
 #endif
 

--- a/modern/tests/CMakeLists.txt
+++ b/modern/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ include_directories(
 )
 
 set(SPINLOCK_SRC ${CMAKE_CURRENT_SOURCE_DIR}/../../v10/ipc/spinlock.c)
+set(MAILBOX_SRC ${CMAKE_CURRENT_SOURCE_DIR}/../../v10/ipc/libipc/mailbox.c)
 
 add_executable(c23_hello c23_hello.c)
 target_link_libraries(c23_hello PRIVATE Threads::Threads)
@@ -50,6 +51,10 @@ target_link_libraries(mqueue_overflow_test PRIVATE rt)
 add_executable(mqueue_timeout_test mqueue_timeout_test.c)
 target_link_libraries(mqueue_timeout_test PRIVATE rt)
 
+add_executable(mailbox_timeout_test mailbox_timeout_test.c ${SPINLOCK_SRC} ${MAILBOX_SRC})
+target_compile_definitions(mailbox_timeout_test PRIVATE SMP_ENABLED)
+target_link_libraries(mailbox_timeout_test PRIVATE Threads::Threads)
+
 enable_testing()
 add_test(NAME c23_test
     COMMAND /bin/sh ${CMAKE_CURRENT_SOURCE_DIR}/c23_test.sh)
@@ -77,3 +82,4 @@ add_test(NAME mqueue_ordering_test COMMAND $<TARGET_FILE:mqueue_ordering_test>)
 add_test(NAME mqueue_blocking_test COMMAND $<TARGET_FILE:mqueue_blocking_test>)
 add_test(NAME mqueue_overflow_test COMMAND $<TARGET_FILE:mqueue_overflow_test>)
 add_test(NAME mqueue_timeout_test COMMAND $<TARGET_FILE:mqueue_timeout_test>)
+add_test(NAME mailbox_timeout_test COMMAND $<TARGET_FILE:mailbox_timeout_test>)

--- a/modern/tests/Makefile
+++ b/modern/tests/Makefile
@@ -34,6 +34,7 @@ check: all
 	./process_spinlock_stress.sh
 	./ptrace_concurrency_test.sh
 	./spinlock_fairness
+	./mailbox_timeout_test.sh
 
 clean:
 	rm -f $(TESTS) *.txt

--- a/modern/tests/mailbox_timeout_test.c
+++ b/modern/tests/mailbox_timeout_test.c
@@ -1,0 +1,59 @@
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <time.h>
+#include "../../v10/ipc/h/mailbox.h"
+#include "../../v10/ipc/h/mailbox_t.h"
+
+static mailbox_t mb1, mb2;
+
+static void *sender1(void *arg)
+{
+    (void)arg;
+    struct timespec ts1 = {0};
+    ts1.tv_nsec = 100000000; /* 100ms */
+    nanosleep(&ts1, NULL); /* 10 ticks */
+    const char msg[] = "one";
+    mailbox_send(&mb1, msg, sizeof(msg));
+    return NULL;
+}
+
+static void *sender2(void *arg)
+{
+    (void)arg;
+    struct timespec ts2 = {0};
+    ts2.tv_nsec = 200000000; /* 200ms */
+    nanosleep(&ts2, NULL); /* 20 ticks */
+    const char msg[] = "two";
+    mailbox_send(&mb2, msg, sizeof(msg));
+    return NULL;
+}
+
+int main(void)
+{
+    mailbox_init(&mb1);
+    mailbox_init(&mb2);
+
+    pthread_t t1, t2;
+    pthread_create(&t1, NULL, sender1, NULL);
+    pthread_create(&t2, NULL, sender2, NULL);
+
+    char buf[8];
+    size_t len = sizeof(buf);
+    int r1 = Recv_T(&mb2, buf, &len, 15);
+    int ok1 = (r1 == -1);
+
+    len = sizeof(buf);
+    int r2 = Recv_T(&mb1, buf, &len, 15);
+    int ok2 = (r2 == 0 && strcmp(buf, "one") == 0);
+
+    len = sizeof(buf);
+    int r3 = Recv_T(&mb2, buf, &len, 30);
+    int ok3 = (r3 == 0 && strcmp(buf, "two") == 0);
+
+    pthread_join(t1, NULL);
+    pthread_join(t2, NULL);
+
+    return (ok1 && ok2 && ok3) ? 0 : 1;
+}

--- a/modern/tests/mailbox_timeout_test.sh
+++ b/modern/tests/mailbox_timeout_test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+clang -std=c23 -Wall -Wextra -Werror -pthread \
+    mailbox_timeout_test.c ../../v10/ipc/libipc/mailbox.c \
+    ../../v10/ipc/spinlock.c -I ../compat -I ../../v10/ipc/h \
+    -DSMP_ENABLED -o mailbox_timeout_test
+./mailbox_timeout_test

--- a/modern/tests/ptrace_concurrency_test.c
+++ b/modern/tests/ptrace_concurrency_test.c
@@ -1,3 +1,5 @@
+#define _XOPEN_SOURCE 700
+#define _POSIX_C_SOURCE 200809L
 #include <pthread.h>
 #include <signal.h>
 #include <stdio.h>
@@ -6,6 +8,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <time.h>
 
 #define CHILDREN 4
 
@@ -20,7 +23,9 @@ void *tracer(void *arg)
     }
     waitpid(pid, NULL, 0);
     ptrace(PTRACE_CONT, pid, NULL, NULL);
-    usleep(100000);
+    struct timespec ts = {0};
+    ts.tv_nsec = 100000000; /* 100ms */
+    nanosleep(&ts, NULL);
     ptrace(PTRACE_DETACH, pid, NULL, NULL);
     return NULL;
 }

--- a/modern/tests/spinlock_fairness.c
+++ b/modern/tests/spinlock_fairness.c
@@ -1,6 +1,7 @@
 #include <pthread.h>
 #include <stdio.h>
 #include <unistd.h>
+#include <time.h>
 #include "../compat/spinlock.h"
 
 static SPINLOCK_ALIGNED spinlock_t lock = SPINLOCK_INITIALIZER;
@@ -23,9 +24,11 @@ int main(void)
     /* Hold the lock so both threads queue up */
     spin_lock(&lock);
     pthread_create(&t1, NULL, worker, (void *)0);
-    usleep(10000); /* ensure thread 0 waits first */
+    struct timespec ts = {0};
+    ts.tv_nsec = 10000000;
+    nanosleep(&ts, NULL); /* ensure thread 0 waits first */
     pthread_create(&t2, NULL, worker, (void *)1);
-    usleep(10000);
+    nanosleep(&ts, NULL);
     spin_unlock(&lock);
 
     pthread_join(t1, NULL);

--- a/modern/tests/spinlock_test.c
+++ b/modern/tests/spinlock_test.c
@@ -7,6 +7,7 @@ static int counter = 0;
 
 void *worker(void *arg)
 {
+    (void)arg;
     for(int i=0; i<100000; i++) {
         spin_lock(&lock);
         counter++;

--- a/modern/tests/thread_spinlock_stress.c
+++ b/modern/tests/thread_spinlock_stress.c
@@ -10,6 +10,7 @@ static int counter = 0;
 
 void *worker(void *arg)
 {
+    (void)arg;
     for(int i = 0; i < ITERATIONS; i++) {
         spin_lock(&lock);
         counter++;

--- a/v10/ipc/h/mailbox_t.h
+++ b/v10/ipc/h/mailbox_t.h
@@ -1,0 +1,13 @@
+#ifndef MAILBOX_T_H
+#define MAILBOX_T_H
+
+#include "mailbox.h"
+
+int mailbox_recv_t(mailbox_t *mb, void *buf, size_t *len, unsigned timeout);
+
+static inline int Recv_T(mailbox_t *mb, void *buf, size_t *len, unsigned timeout)
+{
+    return mailbox_recv_t(mb, buf, len, timeout);
+}
+
+#endif /* MAILBOX_T_H */

--- a/v10/ipc/h/spinlock.h
+++ b/v10/ipc/h/spinlock.h
@@ -6,6 +6,10 @@
 #include <stdatomic.h>
 #include <stdalign.h>
 
+#ifndef ATOMIC_VAR_INIT
+#define ATOMIC_VAR_INIT(value) (value)
+#endif
+
 #if defined(__GCC_DESTRUCTIVE_SIZE)
 #define SPINLOCK_CACHE_LINE_SIZE __GCC_DESTRUCTIVE_SIZE
 #elif defined(__x86_64__) || defined(__i386__)

--- a/v10/ipc/libipc/mailbox.c
+++ b/v10/ipc/libipc/mailbox.c
@@ -1,5 +1,7 @@
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
+#include <time.h>
 #include "../h/mailbox.h"
 
 void mailbox_init(mailbox_t *mb)
@@ -68,5 +70,23 @@ int exo_send(mailbox_t *target, const void *buf, size_t len)
 int exo_recv(mailbox_t *mb, void *buf, size_t *len)
 {
     return mailbox_recv(mb, buf, len);
+}
+
+#define TICK_USEC 10000
+
+int mailbox_recv_t(mailbox_t *mb, void *buf, size_t *len, unsigned timeout)
+{
+    unsigned waited = 0;
+    while (waited <= timeout) {
+        if (mailbox_recv(mb, buf, len) == 0)
+            return 0;
+        if (waited == timeout)
+            break;
+        struct timespec ts = {0};
+        ts.tv_nsec = TICK_USEC * 1000u;
+        nanosleep(&ts, NULL);
+        waited++;
+    }
+    return -1;
 }
 


### PR DESCRIPTION
## Summary
- extend `mailbox.c` with `mailbox_recv_t()` using nanosleep
- expose wrapper `Recv_T()` in new header `mailbox_t.h`
- update IPC documentation with usage of `Recv_T`
- add multi-queue timeout regression test
- adjust existing tests for newer compilers

## Testing
- `make -C modern/tests check`