### PR TITLE
Add -Wall -Werror flags

### DIFF
--- a/v10/sys/Makefile
+++ b/v10/sys/Makefile
@@ -11,7 +11,7 @@ else
 SPINLOCK=-DSPINLOCK_UNIPROCESSOR
 endif
 
-CFLAGS += -std=c23 $(SPINLOCK) -I.
+CFLAGS += -std=c23 $(SPINLOCK) -I. -Wall -Werror
 
 export CROSS_COMPILE ARCH CC CFLAGS SMP
 

--- a/v10/sys/fs/Makefile
+++ b/v10/sys/fs/Makefile
@@ -1,7 +1,7 @@
 CROSS_COMPILE ?=
 CC ?= $(CROSS_COMPILE)gcc
 CFLAGS ?= -O
-CFLAGS += -std=c23 -I ..
+CFLAGS += -std=c23 -I .. -Wall -Werror
 
 SRC_C := $(wildcard *.c)
 SRC_S := $(wildcard *.s)

--- a/v10/sys/inet/Makefile
+++ b/v10/sys/inet/Makefile
@@ -1,7 +1,7 @@
 CROSS_COMPILE ?=
 CC ?= $(CROSS_COMPILE)gcc
 CFLAGS ?= -O
-CFLAGS += -std=c23 -I ..
+CFLAGS += -std=c23 -I .. -Wall -Werror
 
 SRC_C := $(wildcard *.c)
 SRC_S := $(wildcard *.s)

--- a/v10/sys/io/Makefile
+++ b/v10/sys/io/Makefile
@@ -1,7 +1,7 @@
 CROSS_COMPILE ?=
 CC ?= $(CROSS_COMPILE)gcc
 CFLAGS ?= -O
-CFLAGS += -std=c23 -I ..
+CFLAGS += -std=c23 -I .. -Wall -Werror
 
 SRC_C := $(wildcard *.c)
 SRC_S := $(wildcard *.s)

--- a/v10/sys/md/Makefile
+++ b/v10/sys/md/Makefile
@@ -1,7 +1,7 @@
 CROSS_COMPILE ?=
 CC ?= $(CROSS_COMPILE)gcc
 CFLAGS ?= -O
-CFLAGS += -std=c23 -I ..
+CFLAGS += -std=c23 -I .. -Wall -Werror
 
 SRC_C := $(wildcard *.c)
 SRC_S := $(wildcard *.s)

--- a/v10/sys/ml/Makefile
+++ b/v10/sys/ml/Makefile
@@ -1,7 +1,7 @@
 CROSS_COMPILE ?=
 CC ?= $(CROSS_COMPILE)gcc
 CFLAGS ?= -O
-CFLAGS += -std=c23 -I ..
+CFLAGS += -std=c23 -I .. -Wall -Werror
 
 SRC_C := $(wildcard *.c)
 SRC_S := $(wildcard *.s)

--- a/v10/sys/os/Makefile
+++ b/v10/sys/os/Makefile
@@ -1,7 +1,7 @@
 CROSS_COMPILE ?=
 CC ?= $(CROSS_COMPILE)gcc
 CFLAGS ?= -O
-CFLAGS += -std=c23 -I ..
+CFLAGS += -std=c23 -I .. -Wall -Werror
 
 SRC_C := $(wildcard *.c)
 # ensure scheduler lock support is built

--- a/v10/sys/vm/Makefile
+++ b/v10/sys/vm/Makefile
@@ -1,7 +1,7 @@
 CROSS_COMPILE ?=
 CC ?= $(CROSS_COMPILE)gcc
 CFLAGS ?= -O
-CFLAGS += -std=c23 -I ..
+CFLAGS += -std=c23 -I .. -Wall -Werror
 
 SRC_C := $(wildcard *.c)
 SRC_S := $(wildcard *.s)


### PR DESCRIPTION
## Summary
- compile kernels with warnings treated as errors

## Testing
- `make clean`
- `make -j$(nproc)` *(fails: unknown type errors)*