### PR TITLE
Fix pointer casts to use uintptr_t

### DIFF
--- a/r70/oCC/varargs.h
+++ b/r70/oCC/varargs.h
@@ -1,3 +1,4 @@
+#include <stdint.h>
 
 #ifndef va_start
 
@@ -24,7 +25,7 @@ typedef char *va_list;
 #define va_end(list)
 #ifdef u370
 #define va_arg(list, mode) ((mode *)(list = \
-	(char *) ((int)list + 2*sizeof(mode) - 1 & -sizeof(mode))))[-1]
+	(char *) (((uintptr_t)list) + 2*sizeof(mode) - 1 & -sizeof(mode))))[-1]
 #else
 #define va_arg(list, mode) ((mode *)(list += sizeof(mode)))[-1]
 #endif

--- a/v10/dk/cmd/pupu/dkcanon.c
+++ b/v10/dk/cmd/pupu/dkcanon.c
@@ -1,8 +1,9 @@
+#include <stdint.h>
 
-#define	SALIGN(p)	(char *)(((int)p+1) & ~1)
-#define	LALIGN(p)	(char *)(((int)p+3) & ~3)
-#define	SNEXT(p)	(char *)((int)p + sizeof (short))
-#define	LNEXT(p)	(char *)((int)p + sizeof (long))
+#define SALIGN(p)       (char *)(((uintptr_t)(p)+1) & ~1)
+#define LALIGN(p)       (char *)(((uintptr_t)(p)+3) & ~3)
+#define SNEXT(p)        (char *)((uintptr_t)(p) + sizeof(short))
+#define LNEXT(p)        (char *)((uintptr_t)(p) + sizeof(long))
 
 
 /*

--- a/v10/ipc/bin/OLDdkcc/dkcanon.c
+++ b/v10/ipc/bin/OLDdkcc/dkcanon.c
@@ -1,8 +1,9 @@
+#include <stdint.h>
 
-#define	SALIGN(p)	(char *)(((int)p+1) & ~1)
-#define	LALIGN(p)	(char *)(((int)p+3) & ~3)
-#define	SNEXT(p)	(char *)((int)p + sizeof (short))
-#define	LNEXT(p)	(char *)((int)p + sizeof (long))
+#define SALIGN(p)       (char *)(((uintptr_t)(p)+1) & ~1)
+#define LALIGN(p)       (char *)(((uintptr_t)(p)+3) & ~3)
+#define SNEXT(p)        (char *)((uintptr_t)(p) + sizeof(short))
+#define LNEXT(p)        (char *)((uintptr_t)(p) + sizeof(long))
 
 
 /*

--- a/v10/ipc/bin/pupu/dkcanon.c
+++ b/v10/ipc/bin/pupu/dkcanon.c
@@ -1,8 +1,9 @@
+#include <stdint.h>
 
-#define	SALIGN(p)	(char *)(((int)p+1) & ~1)
-#define	LALIGN(p)	(char *)(((int)p+3) & ~3)
-#define	SNEXT(p)	(char *)((int)p + sizeof (short))
-#define	LNEXT(p)	(char *)((int)p + sizeof (long))
+#define SALIGN(p)       (char *)(((uintptr_t)(p)+1) & ~1)
+#define LALIGN(p)       (char *)(((uintptr_t)(p)+3) & ~3)
+#define SNEXT(p)        (char *)((uintptr_t)(p) + sizeof(short))
+#define LNEXT(p)        (char *)((uintptr_t)(p) + sizeof(long))
 
 
 /*

--- a/v10/sys/inet/ip_device.c
+++ b/v10/sys/inet/ip_device.c
@@ -4,6 +4,7 @@
  */
 
 #include "sys/param.h"
+#include <stdint.h>
 #include "sys/stream.h"
 #include "sys/conf.h"
 #include "sys/inet/in.h"
@@ -41,7 +42,7 @@ dev_t dev;
 ipdclose(q)
 register struct queue *q;
 {
-	ipdstate[(int)q->ptr] = 0;
+	ipdstate[(uintptr_t)q->ptr] = 0;
 }
 
 ipdput(q, bp)

--- a/v10/sys/io/connld.c
+++ b/v10/sys/io/connld.c
@@ -5,6 +5,7 @@
  */
 
 #include "sys/param.h"
+#include <stdint.h>
 #include "sys/stream.h"
 #include "sys/filio.h"
 #include "sys/conf.h"
@@ -34,7 +35,7 @@ register struct queue *q;
 	register struct queue *nq;
 	register ioc;
 
-	if ((int)q->ptr == 0) {		/* the open on push does nothing */
+	if ((uintptr_t)q->ptr == 0) {		/* the open on push does nothing */
 		q->ptr = (caddr_t)1;
 		return(1);
 	}

--- a/v10/sys/io/cure.c
+++ b/v10/sys/io/cure.c
@@ -4,6 +4,7 @@
  *	(the latter not severe, as 256 channels are permitted)
  */
 #include "sys/param.h"
+#include <stdint.h>
 #include "sys/stream.h"
 #include "sys/dkio.h"
 #include "sys/ubaddr.h"
@@ -636,7 +637,7 @@ register struct block *bp;
 #define	BOOTOK	020		/* initialization flag */
 
 	register struct device *mp =
-	     (struct device *)ubaddr(&rcureaddr[(int)q->ptr & DV]);
+	     (struct device *)ubaddr(&rcureaddr[(uintptr_t)q->ptr & DV]);
 	register int csr, n;
 
 	switch(bp->type) {
@@ -656,7 +657,7 @@ register struct block *bp;
 		return;
 
 	case M_DATA:
-		if (((int)q->ptr&BOOTOK) == 0) {		/* first write */
+		if (((uintptr_t)q->ptr&BOOTOK) == 0) {		/* first write */
 			if ((mp->csr&STATE) != SBOOT) {
 				printf("cure not ready to load, %o\n", mp->csr);
 				goto err;
@@ -667,7 +668,7 @@ register struct block *bp;
 				printf("cure load err0 %o\n", mp->csr);
 				goto err;
 			}
-			q->ptr = (caddr_t)((int)q->ptr | BOOTOK);
+			q->ptr = (caddr_t)((uintptr_t)q->ptr | BOOTOK);
 		}
 		while (bp->rptr < bp->wptr) {
 			if ((mp->csr&STATE) != SBOOTING) {

--- a/v10/sys/io/debna.c
+++ b/v10/sys/io/debna.c
@@ -4,6 +4,7 @@
  * disallows use of the storage port
  */
 #include "sys/param.h"
+#include <stdint.h>
 #include "sys/biaddr.h"
 #include "sys/conf.h"
 #include "sys/user.h"
@@ -113,17 +114,17 @@ register int unit;
 	if (bn->bvp.d->f[PFREQ].f_size == 0) {	/* somewhat sleazy init flag */
 		bn->bvp.d->f[PFREQ].f_size = BNABSIZE-BVPHSIZE;
 		cp = bnabuf[unit].rbuf;
-		cp = (char *)(((int)cp + 7) & ~07);	/* quad-align */
+		cp = (char *)(((uintptr_t)cp + 7) & ~07);	/* quad-align */
 		for (i = 0; i < BNARBUF; i++, cp += BNABSIZE) {
-			if (((int)cp&PGOFSET) > (((int)cp+sizeof(struct bvpdg))&PGOFSET))
-				cp = (char *)(((int)cp+PGOFSET)&~PGOFSET);
+			if (((uintptr_t)cp&PGOFSET) > (((uintptr_t)cp+sizeof(struct bvpdg))&PGOFSET))
+				cp = (char *)(((uintptr_t)cp+PGOFSET)&~PGOFSET);
 			bnarbuf(bn, (struct dgi *)cp);
 		}
 		cp = bnabuf[unit].xbuf;
-		cp = (char *)(((int)cp + 7) & ~07);	/* quad-align */
+		cp = (char *)(((uintptr_t)cp + 7) & ~07);	/* quad-align */
 		for (i = 0; i < BNAXBUF; i++, cp += BNABSIZE) {
-			if (((int)cp&PGOFSET) > (((int)cp+sizeof(struct bvpdg))&PGOFSET))
-				cp = (char *)(((int)cp+PGOFSET)&~PGOFSET);
+			if (((uintptr_t)cp&PGOFSET) > (((uintptr_t)cp+sizeof(struct bvpdg))&PGOFSET))
+				cp = (char *)(((uintptr_t)cp+PGOFSET)&~PGOFSET);
 			bnaxbuf(bn, (struct dgi *)cp);
 		}
 	}

--- a/v10/sys/io/im.c
+++ b/v10/sys/io/im.c
@@ -24,6 +24,7 @@ enum states {
 #include "sys/user.h"
 #include "sys/buf.h"
 #include "sys/ubaddr.h"
+#include <stdint.h>
 #include "sys/systm.h"
 
 #include "sys/im.h"
@@ -166,7 +167,7 @@ register struct buf *bp;
 	uaddr_t uaddr;
 	u_short csr;
 
-	if(bp->b_bcount<=0 || (bp->b_bcount&1) || ((int)bp->b_un.b_addr&1)){
+	if(bp->b_bcount<=0 || (bp->b_bcount&1) || (((uintptr_t)bp->b_un.b_addr)&1)){
 		bp->b_flags |= B_ERROR;
 		iodone(bp);
 		return;

--- a/v10/sys/io/kb.c
+++ b/v10/sys/io/kb.c
@@ -4,6 +4,7 @@
  *	(the latter not severe, as 256 channels are permitted)
  */
 #include "sys/param.h"
+#include <stdint.h>
 #include "sys/stream.h"
 #include "sys/dkio.h"
 #include "sys/ubaddr.h"
@@ -307,7 +308,7 @@ register struct kbkmc *kk;
 		return;
 	}
 	kk->ibuf = bp;
-	if ((int)bp->rptr & 01)
+	if ((uintptr_t)bp->rptr & 01)
 		bp->rptr++;
 	kk->iaddr = ua = ubadrptr(kk->ubno, bp, kk->imap);
 	reg->bc = bp->rptr - bp->lim;	/* sic - negative count */

--- a/v10/sys/io/mg.c
+++ b/v10/sys/io/mg.c
@@ -2,6 +2,7 @@
  * DR11C for Mergenthaler 202
  */
 #include "sys/param.h"
+#include <stdint.h>
 #include "sys/conf.h"
 #include "sys/stream.h"
 #include "sys/ubaddr.h"
@@ -83,9 +84,9 @@ register struct queue *q;
 mgclose(q)
 register struct queue *q;
 {
-	register struct mg *mp = &mg[((int)q->ptr) >> 1];
+	register struct mg *mp = &mg[((uintptr_t)q->ptr) >> 1];
 
-	if(((int)q->ptr) & 01) {
+	if(((uintptr_t)q->ptr) & 01) {
 		mp->wq = NULL;
 	}
 	else {
@@ -131,7 +132,7 @@ register struct block *bp;
 
 	case M_DATA:
 		putq(q, bp);
-		mgstart(&mg[((int)q->ptr) >> 1]);
+		mgstart(&mg[((uintptr_t)q->ptr) >> 1]);
 		return;
 
 	default:

--- a/v10/sys/io/okb.c
+++ b/v10/sys/io/okb.c
@@ -4,6 +4,7 @@
  *	(the latter not severe, as 256 channels are permitted)
  */
 #include "sys/param.h"
+#include <stdint.h>
 #include "sys/stream.h"
 #include "sys/dkio.h"
 #include "sys/ubaddr.h"
@@ -310,7 +311,7 @@ register struct kbkmc *kk;
 		return;
 	}
 	kk->ibuf = bp;
-	if ((int)bp->rptr & 01)
+	if ((uintptr_t)bp->rptr & 01)
 		bp->rptr++;
 	kk->iaddr = ua = ubadrptr(kk->ubno, bp, kk->imap);
 	reg->bc = bp->rptr - bp->lim;	/* sic - negative count */

--- a/v10/sys/io/spipe.c
+++ b/v10/sys/io/spipe.c
@@ -2,6 +2,7 @@
  * stream pipe
  */
 #include "sys/param.h"
+#include <stdint.h>
 #include "sys/stream.h"
 #include "sys/conf.h"
 
@@ -54,7 +55,7 @@ register struct queue *q;
 		putctl(oq->next, M_HANGUP);
 		WR(oq)->ptr = NULL;
 	}
-	spipes[minor((int)q->ptr)] = NULL;
+	spipes[minor((uintptr_t)q->ptr)] = NULL;
 }
 
 spsrv(q)

--- a/v10/sys/md/ubamap.c
+++ b/v10/sys/md/ubamap.c
@@ -4,6 +4,7 @@
 
 #include "sys/param.h"
 #include "sys/ubaddr.h"
+#include <stdint.h>
 #include "sys/map.h"
 #include "sys/uba.h"
 #include "sys/buf.h"
@@ -138,8 +139,8 @@ int size;
 {
 	register int off;
 
-	off = (int)cp & PGOFSET;
-	return (ubmsetmap(u, &Sysmap[btop((int)cp & ~KSTART)],
+	off = ((uintptr_t)cp) & PGOFSET;
+	return (ubmsetmap(u, &Sysmap[btop(((uintptr_t)cp) & ~KSTART)],
 		btoc(size + off), um) + off);
 }
 
@@ -176,7 +177,7 @@ ubm_t um;
 {
 	register int off;
 
-	off = (int)bp->b_un.b_addr & PGOFSET;
+	off = ((uintptr_t)bp->b_un.b_addr) & PGOFSET;
 	return (ubmsetmap(u, btopte(bp), btoc(bp->b_bcount + off), um) + off);
 }
 

--- a/v10/sys/vm/vmsubr.c
+++ b/v10/sys/vm/vmsubr.c
@@ -1,6 +1,7 @@
 /*	vmsubr.c	4.6	81/05/28	*/
 
 #include "sys/param.h"
+#include <stdint.h>
 #include "sys/systm.h"
 #include "sys/user.h"
 #include "sys/vm.h"
@@ -103,7 +104,7 @@ register struct buf *bp;
 	else
 		rp = bp->b_proc;
 	if ((bp->b_flags & B_PHYS) == 0)
-		return(&Sysmap[btop(((int)bp->b_un.b_addr)&~KSTART)]);
+		return(&Sysmap[btop(((uintptr_t)bp->b_un.b_addr)&~KSTART)]);
 	else if (bp->b_flags & B_UAREA)
 		return(&rp->p_addr[btop(bp->b_un.b_addr)]);
 	else if (bp->b_flags & B_PAGET)


### PR DESCRIPTION
## Summary
- use uintptr_t casts in dkcanon and kernel code
- include `<stdint.h>` where needed

## Testing
- `make check` *(fails: unrecognized option '-std=c23')*