### PR TITLE
Add Coq skeleton for Unix v10 migration

### DIFF
--- a/unix-v10-coq/Makefile
+++ b/unix-v10-coq/Makefile
@@ -1,0 +1,13 @@
+COQFILES := $(shell find theories -name '*.v')
+
+all: vo
+
+vo: _CoqProject $(COQFILES)
+	coq_makefile -f _CoqProject -o Makefile.coq
+	$(MAKE) -f Makefile.coq
+
+clean:
+	$(MAKE) -f Makefile.coq clean || true
+	rm -f Makefile.coq
+
+.PHONY: all vo clean

--- a/unix-v10-coq/README.md
+++ b/unix-v10-coq/README.md
@@ -1,0 +1,16 @@
+# Unix v10 Coq Framework
+
+This directory contains a minimal Coq skeleton for reasoning
+about the migration of Research Unix v10 code to modern C23.
+The structure mirrors the high level design proposed in the
+project documentation.  Modules for the `lambda`, `pi`, `mu`
+and `nu` calculi are provided with placeholder definitions,
+together with a simple migration functor and a preservation
+lemma.
+
+Build the Coq files using:
+
+```
+make -C unix-v10-coq
+```
+

--- a/unix-v10-coq/_CoqProject
+++ b/unix-v10-coq/_CoqProject
@@ -1,0 +1,8 @@
+-Q theories UnixV10
+
+theories/Core/LambdaCalc.v
+theories/Core/PiCalc.v
+theories/Core/MuCalc.v
+theories/Core/NuCalc.v
+theories/Migration/FunctorF.v
+theories/Proofs/Preservation.v

--- a/unix-v10-coq/theories/Core/LambdaCalc.v
+++ b/unix-v10-coq/theories/Core/LambdaCalc.v
@@ -1,0 +1,27 @@
+(** * Minimal Lambda Calculus for Unix v10 proofs *)
+
+Module LambdaCalc.
+
+Inductive term : Type :=
+| Var : nat -> term
+| App : term -> term -> term
+| Abs : nat -> term -> term.
+
+Reserved Notation "t1 ->beta t2" (at level 40).
+
+Inductive beta : term -> term -> Prop :=
+| beta_step x t u : beta (App (Abs x t) u) (subst x u t)
+| app_l t1 t1' t2 : beta t1 t1' -> beta (App t1 t2) (App t1' t2)
+| app_r t1 t2 t2' : beta t2 t2' -> beta (App t1 t2) (App t1 t2')
+| abs_beta x t t' : beta t t' -> beta (Abs x t) (Abs x t')
+where "t1 ->beta t2" := (beta t1 t2).
+
+(* substitution *)
+Fixpoint subst (x:nat) (s:term) (t:term) : term :=
+  match t with
+  | Var y => if Nat.eqb x y then s else t
+  | App t1 t2 => App (subst x s t1) (subst x s t2)
+  | Abs y t1 => if Nat.eqb x y then t else Abs y (subst x s t1)
+  end.
+
+End LambdaCalc.

--- a/unix-v10-coq/theories/Core/MuCalc.v
+++ b/unix-v10-coq/theories/Core/MuCalc.v
@@ -1,0 +1,10 @@
+(** * Sketch of \mu-calculus for memory management *)
+
+Module MuCalc.
+
+Inductive formula : Type :=
+| FTrue : formula
+| FFalse : formula
+| FMu : nat -> formula -> formula.
+
+End MuCalc.

--- a/unix-v10-coq/theories/Core/NuCalc.v
+++ b/unix-v10-coq/theories/Core/NuCalc.v
@@ -1,0 +1,9 @@
+(** * Sketch of \nu-calculus for scheduling *)
+
+Module NuCalc.
+
+Inductive formula : Type :=
+| FBox : formula -> formula
+| FNu : nat -> formula -> formula.
+
+End NuCalc.

--- a/unix-v10-coq/theories/Core/PiCalc.v
+++ b/unix-v10-coq/theories/Core/PiCalc.v
@@ -1,0 +1,22 @@
+(** * Simple \pi-calculus for IPC *)
+
+Module PiCalc.
+
+Definition chan := nat.
+
+Inductive proc : Type :=
+| Zero : proc
+| Send : chan -> nat -> proc -> proc
+| Recv : chan -> nat -> proc -> proc
+| Par : proc -> proc -> proc.
+
+Reserved Notation "P ->pi Q" (at level 40).
+
+Inductive step : proc -> proc -> Prop :=
+| step_comm c v P Q :
+    step (Par (Send c v P) (Recv c v Q)) (Par P Q)
+| step_par_l P P' Q : step P P' -> step (Par P Q) (Par P' Q)
+| step_par_r P Q Q' : step Q Q' -> step (Par P Q) (Par P Q')
+where "P ->pi Q" := (step P Q).
+
+End PiCalc.

--- a/unix-v10-coq/theories/Migration/FunctorF.v
+++ b/unix-v10-coq/theories/Migration/FunctorF.v
@@ -1,0 +1,13 @@
+(** * Migration functor from C89 to C23 terms *)
+Require Import ../Core/LambdaCalc.
+
+Module FunctorF.
+Import LambdaCalc.
+
+Definition F_obj (t : term) : term := t.
+
+Lemma F_preserve_beta : forall t u,
+  beta t u -> beta (F_obj t) (F_obj u).
+Proof. intros; assumption. Qed.
+
+End FunctorF.

--- a/unix-v10-coq/theories/Proofs/Preservation.v
+++ b/unix-v10-coq/theories/Proofs/Preservation.v
@@ -1,0 +1,9 @@
+(** * Preservation sketch for Unix v10 migration *)
+Require Import ../Core/LambdaCalc.
+Require Import ../Migration/FunctorF.
+
+Lemma lambda_preservation : forall t u,
+  LambdaCalc.beta t u <-> LambdaCalc.beta (FunctorF.F_obj t) (FunctorF.F_obj u).
+Proof.
+  split; intros H; now apply FunctorF.F_preserve_beta.
+Qed.


### PR DESCRIPTION
## Summary
- start `unix-v10-coq` with a minimal Coq project
- define simple lambda, pi, mu and nu calculi
- stub migration functor and preservation lemma
- add README and build instructions

## Testing
- `make -C unix-v10-coq vo` *(fails: `coq_makefile` not found)*