### PR TITLE
Add Cap’n Proto wrapper library and build options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(research_unix_v10 C ASM CXX)
+
+option(USE_CAPNP "Enable Cap'n Proto support" OFF)
+
+add_subdirectory(v10/sys)
+add_subdirectory(modern/tests)
+
+if(USE_CAPNP)
+    add_subdirectory(modern/libcapnp)
+    add_subdirectory(modern/memory_server)
+endif()

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,11 @@
+project('research-unix-v10', ['c', 'cpp', 'asm'])
+
+use_capnp = get_option('use_capnp')
+
+subdir('v10/sys')
+subdir('modern/tests')
+
+if use_capnp
+    subdir('modern/libcapnp')
+    subdir('modern/memory_server')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('use_capnp', type: 'boolean', value: false, description: 'Enable Cap\'n Proto support')

--- a/modern/libcapnp/CMakeLists.txt
+++ b/modern/libcapnp/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.16)
+
+add_library(libcapnp STATIC
+    capnp.cpp
+)
+
+target_include_directories(libcapnp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(libcapnp PUBLIC capnp kj)

--- a/modern/libcapnp/Makefile
+++ b/modern/libcapnp/Makefile
@@ -1,5 +1,5 @@
-CC ?= clang
-CFLAGS ?= -Wall -Wextra -Werror -fPIC
+CXX ?= clang++
+CXXFLAGS ?= -Wall -Wextra -Werror -fPIC
 
 LIB = libcapnp.a
 OBJS = capnp.o
@@ -8,6 +8,9 @@ all: $(LIB)
 
 $(LIB): $(OBJS)
 	ar rcs $@ $(OBJS)
+
+%.o: %.cpp
+	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 clean:
 	rm -f $(LIB) $(OBJS)

--- a/modern/libcapnp/capnp.c
+++ b/modern/libcapnp/capnp.c
@@ -1,2 +1,0 @@
-#include "capnp.h"
-int capnp_dummy(void) { return capnp_init(); }

--- a/modern/libcapnp/capnp.cpp
+++ b/modern/libcapnp/capnp.cpp
@@ -1,0 +1,28 @@
+#include "capnp.h"
+#include <capnp/message.h>
+#include <capnp/serialize.h>
+
+struct capnp_msg {
+    capnp::MallocMessageBuilder builder;
+};
+
+extern "C" {
+
+int capnp_init(void) {
+    return 0;
+}
+
+capnp_msg* capnp_msg_create(void) {
+    return new capnp_msg{};
+}
+
+void capnp_msg_destroy(capnp_msg* msg) {
+    delete msg;
+}
+
+int capnp_write_fd(capnp_msg* msg, int fd) {
+    capnp::writeMessageToFd(fd, msg->builder);
+    return 0;
+}
+
+}

--- a/modern/libcapnp/capnp.h
+++ b/modern/libcapnp/capnp.h
@@ -1,6 +1,20 @@
 #ifndef LIBCAPNP_CAPNP_H
 #define LIBCAPNP_CAPNP_H
 
-static inline int capnp_init(void) { return 0; }
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int capnp_init(void);
+
+typedef struct capnp_msg capnp_msg;
+
+capnp_msg* capnp_msg_create(void);
+void capnp_msg_destroy(capnp_msg* msg);
+int capnp_write_fd(capnp_msg* msg, int fd);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* LIBCAPNP_CAPNP_H */

--- a/modern/libcapnp/meson.build
+++ b/modern/libcapnp/meson.build
@@ -1,0 +1,6 @@
+libcapnp = static_library(
+    'libcapnp',
+    'capnp.cpp',
+    include_directories: include_directories('.'),
+    dependencies: [dependency('capnp', required: false), dependency('kj', required: false)]
+)

--- a/modern/memory_server/CMakeLists.txt
+++ b/modern/memory_server/CMakeLists.txt
@@ -1,0 +1,7 @@
+if(NOT USE_CAPNP)
+    return()
+endif()
+
+add_executable(memory_server memory_server.c)
+target_include_directories(memory_server PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../libcapnp)
+target_link_libraries(memory_server PRIVATE libcapnp)

--- a/modern/memory_server/meson.build
+++ b/modern/memory_server/meson.build
@@ -1,0 +1,7 @@
+if not get_option('use_capnp')
+    subdir_done()
+endif
+
+executable('memory_server', 'memory_server.c',
+    include_directories: include_directories('..'),
+    link_with: libcapnp)

--- a/modern/tests/meson.build
+++ b/modern/tests/meson.build
@@ -1,0 +1,44 @@
+project('modern_tests', 'c')
+
+add_project_arguments('-std=c23', '-Wall', '-Wextra', '-Werror',
+                      '-D_POSIX_C_SOURCE=200809L', '-D_GNU_SOURCE',
+                      language: 'c')
+
+smp_def = '-DSMP_ENABLED'
+spinlock_src = '../../v10/ipc/spinlock.c'
+mailbox_src = '../../v10/ipc/libipc/mailbox.c'
+
+c23_hello = executable('c23_hello', 'c23_hello.c', install: false)
+spinlock_test = executable('spinlock_test', ['spinlock_test.c', spinlock_src],
+                           c_args: [smp_def], install: false)
+thread_spinlock_stress = executable('thread_spinlock_stress', ['thread_spinlock_stress.c', spinlock_src],
+                                    c_args: [smp_def], install: false)
+process_spinlock_stress = executable('process_spinlock_stress', ['process_spinlock_stress.c', spinlock_src],
+                                     c_args: [smp_def], install: false)
+ptrace_concurrency_test = executable('ptrace_concurrency_test', 'ptrace_concurrency_test.c', install: false)
+spinlock_fairness = executable('spinlock_fairness', ['spinlock_fairness.c', spinlock_src],
+                               c_args: [smp_def, '-DUSE_TICKET_LOCK'], install: false)
+mqueue_ordering_test = executable('mqueue_ordering_test', 'mqueue_ordering_test.c',
+                                  link_args: ['-lrt'], install: false)
+mqueue_blocking_test = executable('mqueue_blocking_test', 'mqueue_blocking_test.c',
+                                  link_args: ['-lrt'], install: false)
+mqueue_overflow_test = executable('mqueue_overflow_test', 'mqueue_overflow_test.c',
+                                  link_args: ['-lrt'], install: false)
+mqueue_timeout_test = executable('mqueue_timeout_test', 'mqueue_timeout_test.c',
+                                 link_args: ['-lrt'], install: false)
+mailbox_timeout_test = executable('mailbox_timeout_test', ['mailbox_timeout_test.c', spinlock_src, mailbox_src],
+                                  c_args: [smp_def], install: false)
+
+sh = find_program('sh')
+
+test('c23_test', sh, args: ['c23_test.sh'], workdir: meson.current_source_dir())
+test('spinlock_test', sh, args: ['spinlock_test.sh'], workdir: meson.current_source_dir())
+test('thread_spinlock_stress', sh, args: ['thread_spinlock_stress.sh'], workdir: meson.current_source_dir())
+test('process_spinlock_stress', sh, args: ['process_spinlock_stress.sh'], workdir: meson.current_source_dir())
+test('ptrace_concurrency_test', sh, args: ['ptrace_concurrency_test.sh'], workdir: meson.current_source_dir())
+test('spinlock_fairness', spinlock_fairness)
+test('mqueue_ordering_test', mqueue_ordering_test)
+test('mqueue_blocking_test', mqueue_blocking_test)
+test('mqueue_overflow_test', mqueue_overflow_test)
+test('mqueue_timeout_test', mqueue_timeout_test)
+test('mailbox_timeout_test', mailbox_timeout_test)


### PR DESCRIPTION
## Summary
- add basic `libcapnp` wrapper with simple serialization helpers
- link `memory_server` with the wrapper when enabled
- support `USE_CAPNP` in new CMake and Meson build files

## Testing
- `make check`
- `cmake .. -DUSE_CAPNP=OFF` *(fails: CMAKE_C_COMPILER clang not found)*
- `meson setup build_meson` *(fails: command not found)*