### PR TITLE
Add POSIX wrapper and capability tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,12 @@ test: check
 ifeq ($(CAPNP),1)
 	$(MAKE) -C modern/libcapnp CC=$(CC) all
 	$(MAKE) -C modern/memory_server CC=$(CC) all
-	$(MAKE) -C modern/tests CC=$(CC) mailbox_timeout_test exo_ipc_status_test
+	$(MAKE) -C modern/tests CC=$(CC) mailbox_timeout_test exo_ipc_status_test posix_wrappers_test capability_client
 	./modern/memory_server/memory_server & \
 	memsrv_pid=$$!; \
 	./modern/tests/mailbox_timeout_test; \
 	./modern/tests/exo_ipc_status_test; \
+	./modern/tests/capability_integration_test.sh; \
 	kill $$memsrv_pid
 endif
 

--- a/docs/exokernel/testing.md
+++ b/docs/exokernel/testing.md
@@ -1,0 +1,21 @@
+# Exokernel Testing
+
+The prototype code under `modern/` includes a number of unit tests and
+integration checks.  The simplest way to build and run them is
+
+```sh
+make check
+```
+
+This compiles the test programs in `modern/tests` and executes the full
+suite, including the new POSIX wrapper tests.
+
+Some integration tests rely on the capability-based memory server.  Enable
+these by invoking the top-level `test` target with `CAPNP=1`:
+
+```sh
+make CAPNP=1 test
+```
+
+This builds `libcapnp`, starts the memory server for the duration of the
+run and exercises the capability interaction tests.

--- a/modern/tests/CMakeLists.txt
+++ b/modern/tests/CMakeLists.txt
@@ -55,6 +55,10 @@ add_executable(mailbox_timeout_test mailbox_timeout_test.c ${SPINLOCK_SRC} ${MAI
 target_compile_definitions(mailbox_timeout_test PRIVATE SMP_ENABLED)
 target_link_libraries(mailbox_timeout_test PRIVATE Threads::Threads)
 
+add_executable(posix_wrappers_test posix_wrappers_test.c)
+add_executable(capability_client capability_client.c)
+target_link_libraries(capability_client PRIVATE Threads::Threads)
+
 enable_testing()
 add_test(NAME c23_test
     COMMAND /bin/sh ${CMAKE_CURRENT_SOURCE_DIR}/c23_test.sh)
@@ -83,3 +87,10 @@ add_test(NAME mqueue_blocking_test COMMAND $<TARGET_FILE:mqueue_blocking_test>)
 add_test(NAME mqueue_overflow_test COMMAND $<TARGET_FILE:mqueue_overflow_test>)
 add_test(NAME mqueue_timeout_test COMMAND $<TARGET_FILE:mqueue_timeout_test>)
 add_test(NAME mailbox_timeout_test COMMAND $<TARGET_FILE:mailbox_timeout_test>)
+add_test(NAME posix_wrappers_test
+    COMMAND /bin/sh ${CMAKE_CURRENT_SOURCE_DIR}/posix_wrappers_test.sh)
+set_tests_properties(posix_wrappers_test PROPERTIES WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_test(NAME capability_integration_test
+    COMMAND /bin/sh ${CMAKE_CURRENT_SOURCE_DIR}/capability_integration_test.sh)
+set_tests_properties(capability_integration_test PROPERTIES WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/modern/tests/Makefile
+++ b/modern/tests/Makefile
@@ -6,7 +6,7 @@ SPINLOCK_SRC = ../../v10/ipc/spinlock.c
 
 TESTS = c23_hello spinlock_test thread_spinlock_stress \
         process_spinlock_stress ptrace_concurrency_test spinlock_fairness \
-        exo_ipc_status_test
+        exo_ipc_status_test posix_wrappers_test capability_client
 
 all: $(TESTS)
 
@@ -31,6 +31,15 @@ spinlock_fairness: spinlock_fairness.c $(SPINLOCK_SRC)
 exo_ipc_status_test: exo_ipc_status_test.c $(SPINLOCK_SRC) ../../v10/ipc/libipc/mailbox.c
 	$(CC) $(CFLAGS) $< ../../v10/ipc/libipc/mailbox.c $(SPINLOCK_SRC) -o $@
 
+	posix_wrappers_test: posix_wrappers_test.c
+	$(CC) $(CFLAGS) $< -o $@
+
+	capability_client: capability_client.c ../libcapnp/libcapnp.a
+		$(CC) $(CFLAGS) $< ../libcapnp/libcapnp.a -o $@
+	
+	../libcapnp/libcapnp.a:
+	$(MAKE) -C ../libcapnp CC=$(CC) all
+
 check: all
 	./c23_test.sh
 	./spinlock_test.sh
@@ -40,6 +49,8 @@ check: all
 	./spinlock_fairness
 	./mailbox_timeout_test.sh
 	./exo_ipc_status_test
-
+	./posix_wrappers_test.sh
+	./capability_integration_test.sh
+	
 clean:
 	rm -f $(TESTS) *.txt

--- a/modern/tests/capability_client.c
+++ b/modern/tests/capability_client.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include "../libcapnp/capnp.h"
+int main(void) {
+    if (capnp_init() != 0) {
+        fprintf(stderr, "capnp init failed\n");
+        return 1;
+    }
+    printf("capnp init ok\n");
+    return 0;
+}

--- a/modern/tests/capability_integration_test.sh
+++ b/modern/tests/capability_integration_test.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+CC=${CC:-clang}
+# Build libraries and server
+make -C ../libcapnp CC=$CC >/dev/null
+make -C ../memory_server CC=$CC >/dev/null
+# Build client
+$CC -std=c23 -Wall -Wextra -Werror capability_client.c ../libcapnp/libcapnp.a -o capability_client
+# Run server and client
+../memory_server/memory_server &
+server_pid=$!
+./capability_client > capability_client_output.txt
+kill $server_pid || true
+if grep -q "capnp init ok" capability_client_output.txt; then
+    echo "capability integration test passed"
+    exit 0
+else
+    echo "capability integration test failed" >&2
+    exit 1
+fi

--- a/modern/tests/posix_wrappers_test.c
+++ b/modern/tests/posix_wrappers_test.c
@@ -1,0 +1,56 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/wait.h>
+
+static int test_pipe(void) {
+    int fds[2];
+    if (pipe(fds) != 0) {
+        perror("pipe");
+        return 1;
+    }
+    const char msg[] = "hello";
+    if (write(fds[1], msg, sizeof(msg)) != sizeof(msg)) {
+        perror("write");
+        return 1;
+    }
+    char buf[sizeof(msg)];
+    if (read(fds[0], buf, sizeof(buf)) != sizeof(msg)) {
+        perror("read");
+        return 1;
+    }
+    close(fds[0]);
+    close(fds[1]);
+    return memcmp(buf, msg, sizeof(msg)) == 0 ? 0 : 1;
+}
+
+static int test_fork_exec(void) {
+    pid_t pid = fork();
+    if (pid < 0) {
+        perror("fork");
+        return 1;
+    }
+    if (pid == 0) {
+        char *const argv[] = {"/bin/true", NULL};
+        execv("/bin/true", argv);
+        _exit(1);
+    }
+    int status;
+    if (waitpid(pid, &status, 0) < 0) {
+        perror("waitpid");
+        return 1;
+    }
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+        return 1;
+    return 0;
+}
+
+int main(void) {
+    if (test_pipe() != 0)
+        return 1;
+    if (test_fork_exec() != 0)
+        return 1;
+    printf("posix wrapper tests passed\n");
+    return 0;
+}

--- a/modern/tests/posix_wrappers_test.sh
+++ b/modern/tests/posix_wrappers_test.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+CC=${CC:-clang}
+$CC -std=c23 -Wall -Wextra -Werror posix_wrappers_test.c -o posix_wrappers_test
+./posix_wrappers_test > posix_wrappers_output.txt
+if grep -q "posix wrapper tests passed" posix_wrappers_output.txt; then
+    echo "posix wrappers test passed"
+    exit 0
+else
+    echo "posix wrappers test failed" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- add integration test docs to `docs/exokernel/testing.md`
- provide POSIX wrapper tests
- exercise capability interactions with a new client/server test
- extend the test makefiles to build and run the new checks

## Testing
- `make check`