### PR TITLE
Add exokernel build options

### DIFF
--- a/README
+++ b/README
@@ -190,3 +190,18 @@ Continuous integration triggers the verification workflow by calling the
 See the "Booting in QEMU" section above (lines 70‑110) for the
 `lccmkall` cross‑compilation setup script and an example `qemu-system-vax`
 command line.
+
+Exokernel Build
+---------------
+Pass `-DEXO=1` to compile the microkernel services under `v10/sys/services`.
+Additional options control related components:
+
+* `-DBUILD_LIBPOSIX=1` – build `libposix.a` from `v10/sys/libposix`.
+* `-DLINK_SERVICES=1` – link the services library into the `unix` kernel.
+
+For example:
+
+```sh
+cmake -S . -B build -DEXO=1 -DBUILD_LIBPOSIX=1 -DLINK_SERVICES=1
+cmake --build build
+```

--- a/v10/sys/CMakeLists.txt
+++ b/v10/sys/CMakeLists.txt
@@ -13,6 +13,9 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 
 # Option controlling the SMP spinlock implementation
 option(SMP "Enable SMP support" OFF)
+option(EXO "Enable exokernel services" OFF)
+option(BUILD_LIBPOSIX "Build libposix.a" OFF)
+option(LINK_SERVICES "Link microkernel services" OFF)
 if(SMP)
     add_compile_definitions(SPINLOCK_TICKET SMP_ENABLED)
 else()
@@ -33,6 +36,16 @@ file(GLOB SRC_C
     "inet/*.c"
 )
 
+if(EXO)
+    file(GLOB SERVICE_SRC_C
+        "services/*.c"
+    )
+    file(GLOB SERVICE_SRC_S
+        "services/*.s"
+    )
+    add_library(services STATIC ${SERVICE_SRC_C} ${SERVICE_SRC_S})
+endif()
+
 # ensure scheduler lock support is built
 list(APPEND SRC_C os/sched_lock.c)
 list(REMOVE_DUPLICATES SRC_C)
@@ -47,8 +60,23 @@ file(GLOB SRC_S
     "inet/*.s"
 )
 
+if(BUILD_LIBPOSIX)
+    file(GLOB POSIX_SRC
+        "libposix/*.c"
+    )
+    add_library(posix STATIC ${POSIX_SRC})
+endif()
+
 add_executable(unix ${SRC_C} ${SRC_S})
 
 # Do not use the standard C library for linking
 target_link_options(unix PRIVATE -nostdlib)
+
+if(BUILD_LIBPOSIX)
+    target_link_libraries(unix PRIVATE posix)
+endif()
+
+if(LINK_SERVICES AND EXO)
+    target_link_libraries(unix PRIVATE services)
+endif()
 


### PR DESCRIPTION
## Summary
- build microkernel services when `EXO=1`
- allow building `libposix.a`
- allow linking service library
- document new options in README

## Testing
- `make test`
- `sh tools/metrics.sh`