### PR TITLE
Remove exokernel project references

### DIFF
--- a/README
+++ b/README
@@ -191,9 +191,9 @@ See the "Booting in QEMU" section above (lines 70‑110) for the
 `lccmkall` cross‑compilation setup script and an example `qemu-system-vax`
 command line.
 
-Exokernel Build
----------------
-Pass `-DEXO=1` to compile the microkernel services under `v10/sys/services`.
+Optional Services Build
+-----------------------
+Pass `-DSERVICES=1` to compile the optional services under `v10/sys/services`.
 Additional options control related components:
 
 * `-DBUILD_LIBPOSIX=1` – build `libposix.a` from `v10/sys/libposix`.
@@ -202,6 +202,6 @@ Additional options control related components:
 For example:
 
 ```sh
-cmake -S . -B build -DEXO=1 -DBUILD_LIBPOSIX=1 -DLINK_SERVICES=1
+cmake -S . -B build -DSERVICES=1 -DBUILD_LIBPOSIX=1 -DLINK_SERVICES=1
 cmake --build build
 ```

--- a/docs/services/services.md
+++ b/docs/services/services.md
@@ -1,7 +1,9 @@
-# Exokernel Services
+# Modular Kernel Services
 
-This repository experiments with an exokernel style where most OS
-functionality is provided by optional user-level services.  Services
+This repository implements a modular kernel design where much of the
+operating system functionality can be provided by optional user-level
+services.  While the approach borrows ideas from both microkernel and
+exokernel architectures, the base system remains monolithic.  Services
 communicate using a very small message-passing API built around
 capability tokens.  Each service registers a name and a handler
 function.  Clients construct a `srv_message` structure containing a

--- a/docs/services/testing.md
+++ b/docs/services/testing.md
@@ -1,4 +1,4 @@
-# Exokernel Testing
+# Modular Services Testing
 
 The prototype code under `modern/` includes a number of unit tests and
 integration checks.  The simplest way to build and run them is

--- a/v10/sys/CMakeLists.txt
+++ b/v10/sys/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 
 # Option controlling the SMP spinlock implementation
 option(SMP "Enable SMP support" OFF)
-option(EXO "Enable exokernel services" OFF)
+option(SERVICES "Enable optional services" OFF)
 option(BUILD_LIBPOSIX "Build libposix.a" OFF)
 option(LINK_SERVICES "Link microkernel services" OFF)
 if(SMP)
@@ -36,7 +36,7 @@ file(GLOB SRC_C
     "inet/*.c"
 )
 
-if(EXO)
+if(SERVICES)
     file(GLOB SERVICE_SRC_C
         "services/*.c"
     )
@@ -76,7 +76,7 @@ if(BUILD_LIBPOSIX)
     target_link_libraries(unix PRIVATE posix)
 endif()
 
-if(LINK_SERVICES AND EXO)
+if(LINK_SERVICES AND SERVICES)
     target_link_libraries(unix PRIVATE services)
 endif()
 


### PR DESCRIPTION
## Summary
- rename exokernel docs directory to `services`
- reword docs to clarify a monolithic design with optional services
- rename `Exokernel Build` section in README to `Optional Services Build`
- update build instructions to use `SERVICES` CMake option
- rename CMake option `EXO` to `SERVICES`

## Testing
- `make test` *(fails: No such file or directory)*