### PR TITLE
Improve setup script for development

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,3 +1,32 @@
-set -e
+#!/bin/bash
+set -euxo pipefail
+
+# Update package lists
 sudo apt-get update
-sudo apt-get install -y clang build-essential cmake make ninja-build
+
+# Install build and debug tools
+sudo apt-get install -y \
+  clang lld lldb clang-tools \
+  build-essential cmake make ninja-build \
+  autoconf automake libtool pkg-config \
+  gdb valgrind afl++ \
+  clang-tidy clang-format cppcheck \
+  git curl wget nodejs npm \
+  python3 python3-pip python3-venv \
+  lcov
+
+# Upgrade pip and install Python tooling for testing and linting
+sudo -H python3 -m pip install --upgrade pip
+sudo -H python3 -m pip install --no-cache-dir \
+  pytest pytest-cov flake8 black mypy
+
+# Install Node.js tooling for linting if needed
+sudo npm install -g eslint
+
+# Print versions for debugging purposes
+clang --version
+lld --version
+python3 --version
+npm --version
+
+echo "Setup complete"


### PR DESCRIPTION
## Summary
- expand `.codex/setup.sh` to install build, debug, lint and fuzz tools
- add python and node based tooling and show versions when done

## Testing
- `bash .codex/setup.sh` *(fails: Could not connect to proxy)*
- `make check` *(fails: posix_wrappers_test: No such file or directory)*