### PR TITLE
Install bison and configure build tools

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -9,7 +9,7 @@ sudo apt-get install -y \
   clang lld lldb clang-tools \
   build-essential cmake make ninja-build \
   autoconf automake libtool pkg-config \
-  gdb valgrind afl++ \
+  gdb valgrind afl++ bison \
   clang-tidy clang-format cppcheck \
   git curl wget nodejs npm \
   python3 python3-pip python3-venv \
@@ -21,7 +21,14 @@ sudo -H python3 -m pip install --no-cache-dir \
   pytest pytest-cov flake8 black mypy
 
 # Install Node.js tooling for linting if needed
+
 sudo npm install -g eslint
+
+# Export environment variables for build tools
+export CC=clang
+export CXX=clang++
+export YACC=bison
+export BISON_PKGDATADIR=$(bison --print-datadir)
 
 # Print versions for debugging purposes
 clang --version


### PR DESCRIPTION
## Summary
- add `bison` to the dev packages installed during setup
- export `CC`, `CXX`, `YACC`, and `BISON_PKGDATADIR` so bison/clang are used by default

## Testing
- `bash -n .codex/setup.sh`