### PR TITLE
Improve setup script

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,32 +1,66 @@
 #!/bin/bash
-set -euxo pipefail
+set -euo pipefail
+
+# Avoid interactive prompts during package installation
+export DEBIAN_FRONTEND=noninteractive
 
 # Update package lists
-sudo apt-get update
+sudo apt-get update -y
 
-# Install build and debug tools
-sudo apt-get install -y \
-  clang lld lldb clang-tools clangd \
-  build-essential cmake make ninja-build \
-  autoconf automake libtool pkg-config \
-  gdb valgrind afl++ bison ccache \
-  clang-tidy clang-format cppcheck \
-  llvm llvm-dev llvm-bolt bolt \
-  libclang-dev libclang-cpp-dev libclang-common-dev \
-  libc++-dev libc++abi-dev \
-  capnproto capnproto-dev \
-  git curl wget nodejs npm \
-  python3 python3-pip python3-venv \
+# List of apt packages to install.  Each is installed
+# individually so failures do not stop the script.
+apt_packages=(
+  clang lld lldb clang-tools clangd
+  build-essential cmake make ninja-build
+  autoconf automake libtool pkg-config
+  gdb valgrind afl++ bison ccache
+  clang-tidy clang-format cppcheck
+  llvm llvm-dev llvm-bolt bolt
+  libclang-dev libclang-cpp-dev libclang-common-dev
+  libc++-dev libc++abi-dev
+  capnproto capnproto-dev
+  git curl wget nodejs npm
+  python3 python3-pip python3-venv
   lcov
+  agda agda-stdlib coq coqide isabelle tlaplus
+)
+
+for pkg in "${apt_packages[@]}"; do
+  echo "Installing $pkg"
+  if ! sudo apt-get install -y "$pkg"; then
+    echo "Warning: failed to install $pkg" >&2
+  fi
+done
+
+# Clean up apt cache to keep the image small
+sudo apt-get clean
 
 # Upgrade pip and install Python tooling for testing and linting
-sudo -H python3 -m pip install --upgrade pip
-sudo -H python3 -m pip install --no-cache-dir \
-  pytest pytest-cov flake8 black mypy
+sudo -H python3 -m pip install --upgrade pip || true
+pip_packages=(pytest pytest-cov flake8 black mypy pre-commit)
+for pkg in "${pip_packages[@]}"; do
+  echo "Pip installing $pkg"
+  if ! sudo -H python3 -m pip install --no-cache-dir "$pkg"; then
+    echo "Warning: failed to install $pkg" >&2
+  fi
+done
 
 # Install Node.js tooling for linting if needed
+npm_packages=(eslint)
+for pkg in "${npm_packages[@]}"; do
+  echo "NPM installing $pkg"
+  if ! sudo npm install -g "$pkg"; then
+    echo "Warning: failed to install $pkg" >&2
+  fi
+done
 
-sudo npm install -g eslint
+# Initialize git submodules
+git submodule update --init --recursive || true
+
+# Install pre-commit hooks if available
+if command -v pre-commit >/dev/null 2>&1; then
+  pre-commit install || true
+fi
 
 # Export environment variables for build tools
 export CC="ccache clang"
@@ -36,10 +70,10 @@ export BISON_PKGDATADIR=$(bison --print-datadir)
 ccache --max-size=1G
 
 # Print versions for debugging purposes
-clang --version
-lld --version
-ccache --version
-python3 --version
-npm --version
+clang --version || true
+lld --version || true
+ccache --version || true
+python3 --version || true
+npm --version || true
 
 echo "Setup complete"


### PR DESCRIPTION
## Summary
- make the `.codex/setup.sh` script robust to installation failures
- install tooling for pre-commit, pytest and Node
- add installs for Agda, TLA+, Coq and Isabelle
- initialize git submodules in setup

## Testing
- `cmake -S . -B build` *(fails: CMAKE_C_COMPILER clang not found)*
- `make check` *(fails: capnp/message.h: No such file or directory)*