### PR TITLE
Improve Codex setup

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -11,14 +11,16 @@ sudo apt-get update -y
 # individually so failures do not stop the script.
 apt_packages=(
   clang lld lldb clang-tools clangd
+  clang-17 lld-17 lldb-17 clang-tools-17 clang-tidy-17 clang-format-17 clangd-17
   build-essential cmake make ninja-build
   autoconf automake libtool pkg-config
   gdb valgrind afl++ bison ccache
   clang-tidy clang-format cppcheck
-  llvm llvm-dev llvm-bolt bolt
+  llvm llvm-dev llvm-bolt bolt mold
   libclang-dev libclang-cpp-dev libclang-common-dev
   libc++-dev libc++abi-dev
   capnproto capnproto-dev
+  z3 libz3-dev
   git curl wget nodejs npm
   python3 python3-pip python3-venv
   lcov
@@ -67,6 +69,9 @@ export CC="ccache clang"
 export CXX="ccache clang++"
 export YACC=bison
 export BISON_PKGDATADIR=$(bison --print-datadir)
+export CFLAGS="-O3 -pipe -flto=thin -fuse-ld=lld -march=native -fno-omit-frame-pointer -g -mllvm -polly -mllvm -polly-vectorizer=polly"
+export CXXFLAGS="$CFLAGS"
+export LDFLAGS="-fuse-ld=lld -Wl,-O2"
 ccache --max-size=1G
 
 # Print versions for debugging purposes

--- a/README
+++ b/README
@@ -71,7 +71,11 @@ Toolchain setup relies on `clang` and `ccache`.  The helper script
 `.codex/setup.sh` installs the necessary Ubuntu packages including
 `clang-tidy`, `llvm-bolt`, and `capnproto-dev`.  It exports `CC` and
 `CXX` as `ccache clang` so the test builds benefit from compiler
-caching and linting through `clang-tidy`.
+caching and linting through `clang-tidy`.  The script runs
+automatically when the repository is opened in a Codex environment and
+should contain every dependency because network access is disabled
+after setup.  It also sets aggressive `CFLAGS` and `CXXFLAGS` enabling
+LTO and Polly optimizations via LLVM.
 
 For background on the mailbox IPC primitives used in the tests, see
 [docs/IPC.md](docs/IPC.md).


### PR DESCRIPTION
## Summary
- extend `.codex/setup.sh` with additional packages for clang 17, mold, z3, etc.
- export LTO+Polly CFLAGS/CXXFLAGS
- note in `README` that Codex runs the setup script automatically and that it sets optimization flags

## Testing
- `make check` *(fails: `capnp/message.h: No such file or directory`)*