### PR TITLE
Add Codex automation files

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1,0 +1,5 @@
+# Repository rules for Codex
+
+- Whenever the repository opens, diff `.codex/setup.sh` against the upstream template URL.
+- If differences are found, patch the file in place and run `shellcheck` and any `bats` tests.
+- Commit the result with the message `auto-heal setup.sh`.

--- a/.codex/config.yaml
+++ b/.codex/config.yaml
@@ -1,0 +1,1 @@
+approvalMode: full-auto

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "postCreateCommand": "npm install -g @openai/codex && codex -q 'doctor setup.sh'"
+}

--- a/README
+++ b/README
@@ -77,6 +77,11 @@ should contain every dependency because network access is disabled
 after setup.  It also sets aggressive `CFLAGS` and `CXXFLAGS` enabling
 LTO and Polly optimizations via LLVM.
 
+Codex keeps `setup.sh` synced using the rules in `.codex/AGENTS.md`. A
+sample systemd unit is provided at `tools/codex-setup.service` that
+executes `codex -q -a full-auto "doctor setup.sh"` and then runs the
+script before networking becomes available.
+
 For background on the mailbox IPC primitives used in the tests, see
 [docs/IPC.md](docs/IPC.md).
 

--- a/tools/codex-setup.service
+++ b/tools/codex-setup.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Heal and run setup.sh before networking
+DefaultDependencies=no
+Before=network-pre.target
+Wants=network-pre.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/codex -q -a full-auto "doctor setup.sh" && /usr/local/bin/setup.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- automate setup healing with an AGENTS file
- enable full-auto mode for Codex
- add devcontainer config to install Codex
- document Codex setup and provide a systemd unit

## Testing
- `make check` *(fails: capnp/message.h not found)*
- `shellcheck .codex/setup.sh` *(fails: command not found)*