### PR TITLE
auto-heal setup.sh

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -euo pipefail
+set -x
+exec > >(tee -a /var/log/research-unix-setup.log) 2>&1
 
 # Avoid interactive prompts during package installation
 export DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Summary
- enable tracing and log to /var/log/research-unix-setup.log

## Testing
- `shellcheck .codex/setup.sh` *(fails: command not found)*