### PR TITLE
Add root setup script

### DIFF
--- a/README
+++ b/README
@@ -82,6 +82,15 @@ sample systemd unit is provided at `tools/codex-setup.service` that
 executes `codex -q -a full-auto "doctor setup.sh"` and then runs the
 script before networking becomes available.
 
+To bootstrap the environment manually run:
+
+```sh
+./setup.sh
+```
+
+The command logs to `setup.log` and delegates package installation to
+`.codex/setup.sh`.
+
 For background on the mailbox IPC primitives used in the tests, see
 [docs/IPC.md](docs/IPC.md).
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euxo pipefail
+LOGFILE="$(dirname "$0")/setup.log"
+# Log to file while still printing to console
+exec > >(tee -a "$LOGFILE") 2>&1
+
+# Update and upgrade system packages
+sudo apt-get update -y
+sudo apt-get dist-upgrade -y || true
+
+# Delegate to repository-specific script
+bash "$(dirname "$0")/.codex/setup.sh" "$@"


### PR DESCRIPTION
## Summary
- add `setup.sh` in repo root
- log to `setup.log` and delegate to `.codex/setup.sh`
- document usage of the new script in README

## Testing
- `shellcheck .codex/setup.sh` *(fails: command not found)*
- `apt-get update && apt-get install -y shellcheck` *(fails: unable to connect to proxy)*