### PR TITLE
Update docs for new engine paths

### DIFF
--- a/README
+++ b/README
@@ -64,7 +64,7 @@ Run the C23 test suite with:
 
 The script honors the CC environment variable, defaulting to `cc`.
 
-The command compiles a small C23 example under `modern/tests/` and
+The command compiles a small C23 example under `engine/modern/tests/` and
 checks that it runs correctly.
 
 Toolchain setup relies on `clang` and `ccache`.  The helper script
@@ -121,7 +121,7 @@ make test
 Booting in QEMU
 ---------------
 The repository contains source for the VAX version of Research UNIX.
-The files under `v10/sys/` build the kernel while `v10/sys/boot`
+The files under `engine/kernel/` build the kernel while `engine/kernel/boot`
 holds the boot blocks.  Building requires a VAX capable tool chain.
 
 Prerequisites
@@ -148,7 +148,7 @@ Building the kernel and boot loader
    Cross compilation works by exporting the desired compiler before
    running CMake or by using the `tools/cross-env.sh` helper script.
 
-   This populates `v10/sys` with the `unix` kernel image.
+   This populates `engine/kernel` with the `unix` kernel image.
 
 2. Build the MicroVAX boot blocks:
 
@@ -170,7 +170,7 @@ qemu-system-vax -M microvax2 -drive file=disk.img,if=none,id=hd0 \
 ```
 
 Adjust the disk image path and other options to taste.  See the files in
-`v10/sys/boot` for details on the boot code layout.
+`engine/kernel/boot` for details on the boot code layout.
 
 QEMU for x86-64
 ~~~~~~~~~~~~~~~
@@ -208,10 +208,10 @@ command line.
 
 Optional Services Build
 -----------------------
-Pass `-DSERVICES=1` to compile the optional services under `v10/sys/services`.
+Pass `-DSERVICES=1` to compile the optional services under `engine/kernel/services`.
 Additional options control related components:
 
-* `-DBUILD_LIBPOSIX=1` – build `libposix.a` from `v10/sys/libposix`.
+* `-DBUILD_LIBPOSIX=1` – build `libposix.a` from `engine/kernel/libposix`.
 * `-DLINK_SERVICES=1` – link the services library into the `unix` kernel.
 
 For example:

--- a/docs/analysis/build_modernization.md
+++ b/docs/analysis/build_modernization.md
@@ -3,9 +3,9 @@
 This note outlines the current build system layout and sketches a path toward a modern CMake-based workflow.
 
 ## Current Makefile tree
-- **Root `Makefile`:** dispatches to `v10/sys` for the kernel and `modern/tests` for test programs.
-- **`v10/sys/Makefile`:** compiles the Research UNIX kernel from subdirectories (`os`, `vm`, `md`, `io`, `fs`, `ml`, `inet`).
-- **`modern/tests/Makefile`:** builds a small suite of C23 test programs and stress tests.
+- **Root `Makefile`:** dispatches to `engine/kernel` for the kernel and `engine/modern/tests` for test programs.
+- **`engine/kernel/Makefile`:** compiles the Research UNIX kernel from subdirectories (`os`, `vm`, `md`, `io`, `fs`, `ml`, `inet`).
+- **`engine/modern/tests/Makefile`:** builds a small suite of C23 test programs and stress tests.
 - **Other directories:** the repository contains roughly 150 additional `Makefile`s for utilities, the Jerq environment, and assorted tools. A quick count shows:
 
 ```sh
@@ -21,8 +21,8 @@ These auxiliary files follow no single convention and rely on traditional `make`
 3. Gradually replace existing `Makefile`s with CMake targets while preserving the ability to build legacy components.
 
 ### Milestones
-1. **Convert `modern/tests`:** provide simple CMake examples and verify Ninja builds on Linux.
-2. **Convert `v10/sys`:** model the kernel build with CMake object libraries and custom linker scripts.
+1. **Convert `engine/modern/tests`:** provide simple CMake examples and verify Ninja builds on Linux.
+2. **Convert `engine/kernel`:** model the kernel build with CMake object libraries and custom linker scripts.
 3. **Convert `jerq` and related utilities:** migrate graphics and demo programs.
 4. **Convert remaining directories (`r70`, `tools`, etc.):** replace ad-hoc builds and remove obsolete Makefiles.
 

--- a/docs/services/services.md
+++ b/docs/services/services.md
@@ -14,7 +14,7 @@ registered handler.
 ## Directory layout
 
 ```
-v10/sys/services/
+engine/kernel/services/
     services.c      dispatcher and registration logic
     services.h      public API
     fs_proxy.c      example filesystem proxy
@@ -22,7 +22,7 @@ v10/sys/services/
 ```
 
 Individual service objects are built into the kernel just like other
-subsystems.  The top-level `v10/sys/Makefile` now includes the new
+subsystems.  The top-level `engine/kernel/Makefile` now includes the new
 `services` subdirectory.
 
 ## Example services

--- a/docs/services/testing.md
+++ b/docs/services/testing.md
@@ -7,7 +7,7 @@ integration checks.  The simplest way to build and run them is
 make check
 ```
 
-This compiles the test programs in `modern/tests` and executes the full
+This compiles the test programs in `engine/modern/tests` and executes the full
 suite, including the new POSIX wrapper tests.
 
 Some integration tests rely on the capability-based memory server.  Enable


### PR DESCRIPTION
## Summary
- update paths in docs to use `engine/kernel` and `engine/modern/tests`
- keep README and service docs consistent with new layout

## Testing
- `make check` *(fails: capnp/message.h missing)*