### PR TITLE
Add POSIX wrappers and integrate with shell

### DIFF
--- a/modern/compat/posix/exec.h
+++ b/modern/compat/posix/exec.h
@@ -1,0 +1,14 @@
+#ifndef MODERN_COMPAT_POSIX_EXEC_H
+#define MODERN_COMPAT_POSIX_EXEC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int posix_execve(const char *path, char *const argv[], char *const envp[]);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MODERN_COMPAT_POSIX_EXEC_H */

--- a/modern/compat/posix/posix.c
+++ b/modern/compat/posix/posix.c
@@ -1,6 +1,10 @@
 #include "fork.h"
 #include "pipe.h"
+#include "wait.h"
+#include "exec.h"
+
 #include <unistd.h>
+#include <sys/wait.h>
 
 pid_t posix_fork(void)
 {
@@ -10,4 +14,14 @@ pid_t posix_fork(void)
 int posix_pipe(int pipefd[2])
 {
     return pipe(pipefd);
+}
+
+pid_t posix_waitpid(pid_t pid, int *status, int options)
+{
+    return waitpid(pid, status, options);
+}
+
+int posix_execve(const char *path, char *const argv[], char *const envp[])
+{
+    return execve(path, argv, envp);
 }

--- a/modern/compat/posix/wait.h
+++ b/modern/compat/posix/wait.h
@@ -1,0 +1,16 @@
+#ifndef MODERN_COMPAT_POSIX_WAIT_H
+#define MODERN_COMPAT_POSIX_WAIT_H
+
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+pid_t posix_waitpid(pid_t pid, int *status, int options);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MODERN_COMPAT_POSIX_WAIT_H */

--- a/modern/tests/CMakeLists.txt
+++ b/modern/tests/CMakeLists.txt
@@ -58,6 +58,7 @@ target_compile_definitions(mailbox_timeout_test PRIVATE SMP_ENABLED)
 target_link_libraries(mailbox_timeout_test PRIVATE posix Threads::Threads)
 
 add_executable(posix_wrappers_test posix_wrappers_test.c)
+target_link_libraries(posix_wrappers_test PRIVATE posix)
 add_executable(capability_client capability_client.c)
 target_link_libraries(capability_client PRIVATE Threads::Threads)
 

--- a/modern/tests/Makefile
+++ b/modern/tests/Makefile
@@ -31,8 +31,8 @@ spinlock_fairness: spinlock_fairness.c $(SPINLOCK_SRC)
 exo_ipc_status_test: exo_ipc_status_test.c $(SPINLOCK_SRC) ../../v10/ipc/libipc/mailbox.c
 	$(CC) $(CFLAGS) $< ../../v10/ipc/libipc/mailbox.c $(SPINLOCK_SRC) -o $@
 
-posix_wrappers_test: posix_wrappers_test.c
-	$(CC) $(CFLAGS) $< -o $@
+posix_wrappers_test: posix_wrappers_test.c ../compat/posix/posix.c
+	$(CC) $(CFLAGS) $^ -I ../compat/posix -o $@
 
 capability_client: capability_client.c ../libcapnp/libcapnp.a
 	$(CC) $(CFLAGS) $< ../libcapnp/libcapnp.a -o $@

--- a/modern/tests/posix_wrappers_test.c
+++ b/modern/tests/posix_wrappers_test.c
@@ -3,10 +3,14 @@
 #include <string.h>
 #include <unistd.h>
 #include <sys/wait.h>
+#include "../compat/posix/fork.h"
+#include "../compat/posix/pipe.h"
+#include "../compat/posix/wait.h"
+#include "../compat/posix/exec.h"
 
 static int test_pipe(void) {
     int fds[2];
-    if (pipe(fds) != 0) {
+    if (posix_pipe(fds) != 0) {
         perror("pipe");
         return 1;
     }
@@ -26,18 +30,19 @@ static int test_pipe(void) {
 }
 
 static int test_fork_exec(void) {
-    pid_t pid = fork();
+    pid_t pid = posix_fork();
     if (pid < 0) {
         perror("fork");
         return 1;
     }
     if (pid == 0) {
         char *const argv[] = {"/bin/true", NULL};
-        execv("/bin/true", argv);
+        extern char **environ;
+        posix_execve("/bin/true", argv, environ);
         _exit(1);
     }
     int status;
-    if (waitpid(pid, &status, 0) < 0) {
+    if (posix_waitpid(pid, &status, 0) < 0) {
         perror("waitpid");
         return 1;
     }

--- a/modern/tests/posix_wrappers_test.sh
+++ b/modern/tests/posix_wrappers_test.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 set -e
 CC=${CC:-clang}
-$CC -std=c23 -Wall -Wextra -Werror posix_wrappers_test.c -o posix_wrappers_test
+$CC -std=c23 -Wall -Wextra -Werror \
+    ../compat/posix/posix.c posix_wrappers_test.c \
+    -I../compat/posix -o posix_wrappers_test
 ./posix_wrappers_test > posix_wrappers_output.txt
 if grep -q "posix wrapper tests passed" posix_wrappers_output.txt; then
     echo "posix wrappers test passed"

--- a/v10/cmd/sh/io.c
+++ b/v10/cmd/sh/io.c
@@ -8,6 +8,7 @@
 
 #include	"defs.h"
 #include	<fcntl.h>
+#include "../../modern/compat/posix/pipe.h"
 
 short topfd;
 
@@ -89,7 +90,7 @@ poptemp()
 chkpipe(pv)
 int	*pv;
 {
-	if (pipe(pv) < 0 || pv[INPIPE] < 0 || pv[OTPIPE] < 0)
+	if (posix_pipe(pv) < 0 || pv[INPIPE] < 0 || pv[OTPIPE] < 0)
 		error(piperr);
 }
 

--- a/v10/cmd/sh/service.c
+++ b/v10/cmd/sh/service.c
@@ -7,6 +7,8 @@
  */
 
 #include	"defs.h"
+#include "../../modern/compat/posix/wait.h"
+#include "../../modern/compat/posix/exec.h"
 #include	<errno.h>
 
 #ifdef	CRAY
@@ -214,7 +216,7 @@ register char	*t[];
 	trim(p = curstak());
 	sigchk();
 	
-	execve(p, &t[0], xecenv);
+	posix_execve(p, &t[0], xecenv);
 	switch (errno)
 	{
 	case ENOEXEC:		/* could be a shell script */
@@ -303,7 +305,7 @@ int	i, bckg;
 		{
 			register int	*pw = pwlist;
 
-			p = wait(&w);
+			p = posix_waitpid(-1, &w, 0);
 			if (wasintr)
 			{
 				wasintr = 0;

--- a/v10/cmd/sh/xec.c
+++ b/v10/cmd/sh/xec.c
@@ -12,6 +12,7 @@
 #include	<errno.h>
 #include	"sym.h"
 #include	<sys/types.h>
+#include "../../modern/compat/posix/fork.h"
 #include	<sys/stat.h>
 
 static int	parent;
@@ -429,7 +430,7 @@ int	*pf1, *pf2;
 				 * 2,4,8,16, and 32 seconds and then quits
 				 */
 	
-				while ((parent = fork()) == -1)
+				while ((parent = posix_fork()) == -1)
 				{
 					if ((forkcnt = (forkcnt * 2)) > FORKLIM)	/* 32 */
 					{


### PR DESCRIPTION
## Summary
- implement waitpid and execve wrappers in `libposix`
- compile and link test binary against new wrappers
- use wrappers inside the historical shell
- ensure build scripts compile wrappers properly

## Testing
- `make -C modern/tests check` *(fails: capnp headers missing)*