### PR TITLE
Install TLA+ tooling

### DIFF
--- a/.github/workflows/tla.yml
+++ b/.github/workflows/tla.yml
@@ -14,11 +14,12 @@ jobs:
         with:
           distribution: temurin
           java-version: '11'
-      - name: Download TLA+ tools
+      - name: Install TLA+ tools
         run: |
-          curl -L -o tla2tools.jar https://github.com/tlaplus/tlaplus/releases/latest/download/tla2tools.jar
+          sudo apt-get update -y
+          sudo apt-get install -y tlaplus default-jre
       - name: Run TLC
         env:
           JAVA_TOOL_OPTIONS: "-XX:+UseParallelGC"
         run: |
-          java -cp tla2tools.jar tlc2.TLC -deadlock -cleanup -workers 4 verification/TicketLock.tla -config verification/TicketLock.cfg
+          java -cp /usr/share/tlaplus/tla2tools.jar tlc2.TLC -deadlock -cleanup -workers 4 verification/TicketLock.tla -config verification/TicketLock.cfg

--- a/setup.sh
+++ b/setup.sh
@@ -24,6 +24,7 @@ apt_packages=(
   python3 python3-pip python3-venv
   lcov
   agda agda-stdlib coq coqide isabelle tlaplus
+  default-jdk default-jre openjdk-11-jdk openjdk-11-jre-headless
 )
 
 for pkg in "${apt_packages[@]}"; do
@@ -77,6 +78,9 @@ export BISON_PKGDATADIR=$(bison --print-datadir)
 export CFLAGS="-O3 -pipe -flto=thin -fuse-ld=lld -march=native -fno-omit-frame-pointer -g -mllvm -polly -mllvm -polly-vectorizer=polly"
 export CXXFLAGS="$CFLAGS"
 export LDFLAGS="-fuse-ld=lld -Wl,-O2"
+export TLA_HOME="/usr/share/tlaplus"
+export TLA_TOOLS_JAR="$TLA_HOME/tla2tools.jar"
+export PATH="$PATH:$TLA_HOME:$TLA_HOME/bin"
 ccache --max-size=1G
 
 clang --version || true


### PR DESCRIPTION
## Summary
- install OpenJDK and TLA+ packages in `setup.sh`
- export TLA+ environment variables
- install TLA+ via apt in CI workflow

## Testing
- `bash -n setup.sh`