### PR TITLE
Add CI for formal proofs

### DIFF
--- a/.github/workflows/proofs.yml
+++ b/.github/workflows/proofs.yml
@@ -1,0 +1,35 @@
+name: FormalProofs
+
+on:
+  push:
+    branches: ["**"]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: '11'
+      - name: Install dependencies and configure environment
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y curl
+          ./setup.sh
+      - name: Run TLA+ model check
+        env:
+          JAVA_TOOL_OPTIONS: "-XX:+UseParallelGC"
+        run: |
+          java -cp /usr/share/tlaplus/tla2tools.jar tlc2.TLC -deadlock -cleanup -workers 4 verification/TicketLock.tla -config verification/TicketLock.cfg
+      - name: Build Coq proofs
+        run: |
+          make -C unix-v10-coq
+      - name: Check Agda file
+        run: |
+          agda verification/agda/HelloWorld.agda
+      - name: Build Isabelle theory
+        run: |
+          isabelle build -D verification/isabelle

--- a/README
+++ b/README
@@ -233,3 +233,28 @@ For example:
 cmake -S . -B build -DSERVICES=1 -DBUILD_LIBPOSIX=1 -DLINK_SERVICES=1
 cmake --build build
 ```
+
+Formal Verification
+-------------------
+The repository includes lightweight proof artifacts in several languages.
+`setup.sh` configures the toolchains for TLA\+, Coq, Agda and Isabelle/HOL by
+exporting environment variables like `TLA_HOME`, `COQBIN`, `AGDA_BIN` and
+`ISABELLE_HOME`. Continuous integration runs a workflow that checks the
+specifications under `verification/`:
+
+```
+.github/workflows/proofs.yml
+```
+
+The job executes TLC on the TicketLock spec, builds the Coq framework,
+verifies a small Agda module and compiles an Isabelle theory. Invoke the
+workflow locally with:
+
+```sh
+./setup.sh
+java -cp "$TLA_TOOLS_JAR" tlc2.TLC verification/TicketLock.tla \
+  -config verification/TicketLock.cfg
+make -C unix-v10-coq
+agda verification/agda/HelloWorld.agda
+isabelle build -D verification/isabelle
+```

--- a/setup.sh
+++ b/setup.sh
@@ -83,7 +83,14 @@ export TLA_HOME="/usr/share/tlaplus"
 export TLA_TOOLS_JAR="$TLA_HOME/tla2tools.jar"
 export PATH="$PATH:$TLA_HOME:$TLA_HOME/bin"
 export ISABELLE_HOME="/usr/lib/isabelle"
+export ISABELLE_HOME_USER="$HOME/.isabelle"
 export PATH="$PATH:$ISABELLE_HOME/bin"
+export COQBIN="$(dirname $(command -v coqc || echo /usr/bin))"
+export COQLIB="$(coqtop -where 2>/dev/null || echo /usr/lib/coq)"
+export PATH="$PATH:$COQBIN"
+export AGDA_BIN="$(dirname $(command -v agda || echo /usr/bin))"
+export AGDA_DIR="$(agda-mode locate 2>/dev/null || echo $HOME/.agda)"
+export PATH="$PATH:$AGDA_BIN"
 if command -v isabelle >/dev/null 2>&1; then
   isabelle components -I || true
   isabelle components -a || true

--- a/verification/agda/HelloWorld.agda
+++ b/verification/agda/HelloWorld.agda
@@ -1,0 +1,6 @@
+module HelloWorld where
+
+open import Agda.Builtin.Nat
+
+one : Nat
+one = 1

--- a/verification/isabelle/HelloWorld.thy
+++ b/verification/isabelle/HelloWorld.thy
@@ -1,0 +1,8 @@
+theory HelloWorld
+  imports Main
+begin
+
+lemma add_zero: "x + 0 = (x::nat)"
+  by simp
+
+end

--- a/verification/isabelle/ROOT
+++ b/verification/isabelle/ROOT
@@ -1,0 +1,3 @@
+session HelloWorld = HOL +
+  theories
+    HelloWorld


### PR DESCRIPTION
## Summary
- configure toolchains for Coq, Agda and Isabelle in `setup.sh`
- add sample Agda and Isabelle proofs under `verification/`
- document verification workflow in README
- add GitHub Actions workflow running TLA+, Coq, Agda and Isabelle

## Testing
- `sh tools/metrics.sh > metrics_results.log`
- `cmake -S . -B build` *(fails: build errors)*
- `cmake --build build --target test` *(fails: No rule to make target 'test')*
- `make -C modern/tests check` *(fails: missing capnp)*
- `sudo apt-get update` *(fails: no network)*